### PR TITLE
changes made in cmds

### DIFF
--- a/cmd/box/boxpkg/restart.go
+++ b/cmd/box/boxpkg/restart.go
@@ -2,6 +2,8 @@ package boxpkg
 
 import (
 	"github.com/kloudlite/kl/domain/envclient"
+	fn "github.com/kloudlite/kl/pkg/functions"
+	"github.com/kloudlite/kl/pkg/ui/text"
 )
 
 func (c *client) Restart() error {
@@ -9,7 +11,7 @@ func (c *client) Restart() error {
 	if envclient.InsideBox() {
 		fn.Logf(text.Yellow("[#] this will restart current workspace and action will terminate all the processes running in the container. do you want to proceed? [Y/n] "))
 		if !fn.Confirm("y", "y") {
-		  return fn.NewE(fn.NewE(UserCanceled))
+			return fn.NewE(fn.NewE(UserCanceled))
 		}
 		path, err := envclient.GetWorkspacePath()
 		if err != nil {

--- a/cmd/box/boxpkg/restart.go
+++ b/cmd/box/boxpkg/restart.go
@@ -5,6 +5,7 @@ import (
 )
 
 func (c *client) Restart() error {
+
 	if envclient.InsideBox() {
 		path, err := envclient.GetWorkspacePath()
 		if err != nil {

--- a/cmd/box/boxpkg/restart.go
+++ b/cmd/box/boxpkg/restart.go
@@ -7,6 +7,10 @@ import (
 func (c *client) Restart() error {
 
 	if envclient.InsideBox() {
+		fn.Logf(text.Yellow("[#] this will restart current workspace and action will terminate all the processes running in the container. do you want to proceed? [Y/n] "))
+		if !fn.Confirm("y", "y") {
+		  return fn.NewE(fn.NewE(UserCanceled))
+		}
 		path, err := envclient.GetWorkspacePath()
 		if err != nil {
 			return err

--- a/cmd/box/boxpkg/ssh.go
+++ b/cmd/box/boxpkg/ssh.go
@@ -1,6 +1,7 @@
 package boxpkg
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -38,7 +39,10 @@ func (c *client) Ssh() error {
 		return fn.Error("you are already in a devbox")
 	}
 
-	if err := c.Start(); err != nil {
+	err := c.Start()
+	if err != nil && errors.Is(err, UserCanceled) {
+		return nil
+	} else if err != nil {
 		if err2 := c.Stop(); err2 != nil {
 			return fn.NewE(err2)
 		}

--- a/cmd/box/boxpkg/ssh.go
+++ b/cmd/box/boxpkg/ssh.go
@@ -41,6 +41,7 @@ func (c *client) Ssh() error {
 
 	err := c.Start()
 	if err != nil && errors.Is(err, UserCanceled) {
+		log.Println("Operation was canceled by the user")
 		return nil
 	} else if err != nil {
 		if err2 := c.Stop(); err2 != nil {

--- a/cmd/box/boxpkg/ssh.go
+++ b/cmd/box/boxpkg/ssh.go
@@ -41,7 +41,7 @@ func (c *client) Ssh() error {
 
 	err := c.Start()
 	if err != nil && errors.Is(err, UserCanceled) {
-		log.Println("Operation was canceled by the user")
+		fn.Log("Operation was canceled by the user")
 		return nil
 	} else if err != nil {
 		if err2 := c.Stop(); err2 != nil {

--- a/cmd/box/boxpkg/start.go
+++ b/cmd/box/boxpkg/start.go
@@ -48,7 +48,8 @@ func (c *client) Start() error {
 		}
 	}
 
-	if _, err = c.startContainer(boxHash.KLConfHash); err != nil {
+	_, err = c.startContainer(boxHash.KLConfHash)
+	if err != nil {
 		return fn.NewE(err)
 	}
 

--- a/cmd/box/boxpkg/utils.go
+++ b/cmd/box/boxpkg/utils.go
@@ -342,7 +342,7 @@ func (c *client) stopOtherContainers() error {
 	for _, d := range existingContainers {
 		if d.Labels[CONT_PATH_KEY] != c.cwd {
 			spinner.Client.Stop()
-			fn.Logf("An other container is running in %s, do you want to stop it? [Y/n]", d.Labels[CONT_PATH_KEY])
+			fn.Logf("[#] another workspace is active and running at %s. this action will stop that workspace and terminate all the processes running in the that container. do you want to proceed? [Y/n]", d.Labels[CONT_PATH_KEY])
 			if !fn.Confirm("y", "y") {
 				return fn.NewE(fn.NewE(UserCanceled))
 			}

--- a/cmd/box/boxpkg/utils.go
+++ b/cmd/box/boxpkg/utils.go
@@ -41,6 +41,8 @@ const (
 	NO_RUNNING_CONTAINERS = "no container running"
 )
 
+var UserCanceled = fmt.Errorf("user canceled")
+
 type Container struct {
 	Name string
 	Path string
@@ -201,7 +203,8 @@ func (c *client) restartContainer(path string) error {
 
 func (c *client) startContainer(klconfHash string) (string, error) {
 
-	if err := c.stopOtherContainers(); err != nil {
+	err := c.stopOtherContainers()
+	if err != nil {
 		return "", fn.NewE(err)
 	}
 
@@ -341,7 +344,7 @@ func (c *client) stopOtherContainers() error {
 			spinner.Client.Stop()
 			fn.Logf("An other container is running in %s, do you want to stop it? [Y/n]", d.Labels[CONT_PATH_KEY])
 			if !fn.Confirm("y", "y") {
-				continue
+				return fn.NewE(fn.NewE(UserCanceled))
 			}
 
 			if err := c.stopContainer(d.Labels[CONT_PATH_KEY]); err != nil {

--- a/cmd/box/k3d/main.go
+++ b/cmd/box/k3d/main.go
@@ -1,0 +1,11 @@
+package k3d
+
+import (
+	cluster "github.com/k3d-io/k3d/v5/cmd/cluster"
+)
+
+func CreateCluster() {
+	createClusterCmd := cluster.NewCmdClusterCreate()
+	createClusterCmd.SetArgs([]string{"create", "mycluster"})
+	createClusterCmd.Execute()
+}

--- a/cmd/box/restart.go
+++ b/cmd/box/restart.go
@@ -12,7 +12,6 @@ var restartCmd = &cobra.Command{
 	Short: "restart the box according to the current kl.yml configuration",
 	Run: func(cmd *cobra.Command, args []string) {
 
-		fn.Logf(text.Yellow("[#] current process will be stopped, do you want to restart the container? [Y/n] "))
 		if !fn.Confirm(strings.ToUpper("Y"), strings.ToUpper("Y")) {
 			return
 		}

--- a/cmd/box/restart.go
+++ b/cmd/box/restart.go
@@ -3,7 +3,6 @@ package box
 import (
 	"github.com/kloudlite/kl/cmd/box/boxpkg"
 	fn "github.com/kloudlite/kl/pkg/functions"
-	"github.com/kloudlite/kl/pkg/ui/text"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/box/restart.go
+++ b/cmd/box/restart.go
@@ -3,6 +3,7 @@ package box
 import (
 	"github.com/kloudlite/kl/cmd/box/boxpkg"
 	fn "github.com/kloudlite/kl/pkg/functions"
+	"github.com/kloudlite/kl/pkg/ui/text"
 	"github.com/spf13/cobra"
 )
 
@@ -10,6 +11,12 @@ var restartCmd = &cobra.Command{
 	Use:   "restart",
 	Short: "restart the box according to the current kl.yml configuration",
 	Run: func(cmd *cobra.Command, args []string) {
+
+		fn.Logf(text.Yellow("[#] current process will be stopped, do you want to restart the container? [Y/n] "))
+		if !fn.Confirm("Y", "Y") {
+			return
+		}
+
 		c, err := boxpkg.NewClient(cmd, args)
 		if err != nil {
 			fn.PrintError(err)

--- a/cmd/box/restart.go
+++ b/cmd/box/restart.go
@@ -11,11 +11,6 @@ var restartCmd = &cobra.Command{
 	Use:   "restart",
 	Short: "restart the box according to the current kl.yml configuration",
 	Run: func(cmd *cobra.Command, args []string) {
-
-		if !fn.Confirm(strings.ToUpper("Y"), strings.ToUpper("Y")) {
-			return
-		}
-
 		c, err := boxpkg.NewClient(cmd, args)
 		if err != nil {
 			fn.PrintError(err)

--- a/cmd/box/restart.go
+++ b/cmd/box/restart.go
@@ -13,7 +13,7 @@ var restartCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 
 		fn.Logf(text.Yellow("[#] current process will be stopped, do you want to restart the container? [Y/n] "))
-		if !fn.Confirm("Y", "Y") {
+		if !fn.Confirm(strings.ToUpper("Y"), strings.ToUpper("Y")) {
 			return
 		}
 

--- a/cmd/box/start.go
+++ b/cmd/box/start.go
@@ -2,6 +2,7 @@ package box
 
 import (
 	"errors"
+
 	"github.com/kloudlite/kl/cmd/box/boxpkg"
 
 	fn "github.com/kloudlite/kl/pkg/functions"
@@ -14,7 +15,6 @@ var startCmd = &cobra.Command{
 	Use:   "start",
 	Short: "start box using kl.yml configuraiton of the current directory",
 	Run: func(cmd *cobra.Command, args []string) {
-
 		c, err := boxpkg.NewClient(cmd, args)
 		if err != nil {
 			fn.PrintError(err)
@@ -23,9 +23,7 @@ var startCmd = &cobra.Command{
 
 		err = c.Start()
 		if err != nil && errors.Is(err, boxpkg.UserCanceled) {
-			log.Println("Operation canceled by user")
-			return
-		}
+			fn.Log("Operation was canceled by the user")
 			return
 		} else if err != nil {
 			fn.PrintError(err)

--- a/cmd/box/start.go
+++ b/cmd/box/start.go
@@ -1,6 +1,7 @@
 package box
 
 import (
+	"errors"
 	"github.com/kloudlite/kl/cmd/box/boxpkg"
 
 	fn "github.com/kloudlite/kl/pkg/functions"
@@ -20,7 +21,10 @@ var startCmd = &cobra.Command{
 			return
 		}
 
-		if err := c.Start(); err != nil {
+		err = c.Start()
+		if err != nil && errors.Is(err, boxpkg.UserCanceled) {
+			return
+		} else if err != nil {
 			fn.PrintError(err)
 			return
 		}

--- a/cmd/box/start.go
+++ b/cmd/box/start.go
@@ -23,6 +23,9 @@ var startCmd = &cobra.Command{
 
 		err = c.Start()
 		if err != nil && errors.Is(err, boxpkg.UserCanceled) {
+			log.Println("Operation canceled by user")
+			return
+		}
 			return
 		} else if err != nil {
 			fn.PrintError(err)

--- a/cmd/box/stop.go
+++ b/cmd/box/stop.go
@@ -12,7 +12,7 @@ var stopCmd = &cobra.Command{
 	Short: "stop running box",
 	Run: func(cmd *cobra.Command, args []string) {
 
-		fn.Logf(text.Yellow("[#] current process will be stopped, do you want to stop the container? [Y/n] "))
+		fn.Logf(text.Yellow("[#] this action will stop the current workspace. this will end all current running processes in the container. do you want to do you want to proceed? [Y/n] "))
 		if !fn.Confirm(strings.ToUpper("Y"), strings.ToUpper("Y")) {
 			return
 		}

--- a/cmd/box/stop.go
+++ b/cmd/box/stop.go
@@ -13,7 +13,7 @@ var stopCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 
 		fn.Logf(text.Yellow("[#] current process will be stopped, do you want to stop the container? [Y/n] "))
-		if !fn.Confirm("Y", "Y") {
+		if !fn.Confirm(strings.ToUpper("Y"), strings.ToUpper("Y")) {
 			return
 		}
 

--- a/cmd/box/stop.go
+++ b/cmd/box/stop.go
@@ -3,6 +3,7 @@ package box
 import (
 	"github.com/kloudlite/kl/cmd/box/boxpkg"
 	fn "github.com/kloudlite/kl/pkg/functions"
+	"github.com/kloudlite/kl/pkg/ui/text"
 	"github.com/spf13/cobra"
 )
 
@@ -10,6 +11,12 @@ var stopCmd = &cobra.Command{
 	Use:   "stop",
 	Short: "stop running box",
 	Run: func(cmd *cobra.Command, args []string) {
+
+		fn.Logf(text.Yellow("[#] current process will be stopped, do you want to stop the container? [Y/n] "))
+		if !fn.Confirm("Y", "Y") {
+			return
+		}
+
 		c, err := boxpkg.NewClient(cmd, args)
 		if err != nil {
 			fn.PrintError(err)

--- a/cmd/box/stop.go
+++ b/cmd/box/stop.go
@@ -1,6 +1,8 @@
 package box
 
 import (
+	"strings"
+
 	"github.com/kloudlite/kl/cmd/box/boxpkg"
 	fn "github.com/kloudlite/kl/pkg/functions"
 	"github.com/kloudlite/kl/pkg/ui/text"

--- a/cmd/list/apps.go
+++ b/cmd/list/apps.go
@@ -6,8 +6,9 @@ import (
 	"github.com/kloudlite/kl/pkg/functions"
 	fn "github.com/kloudlite/kl/pkg/functions"
 	"github.com/kloudlite/kl/pkg/ui/table"
-
 	"github.com/spf13/cobra"
+	"strconv"
+	"strings"
 )
 
 var appsCmd = &cobra.Command{
@@ -48,14 +49,20 @@ func listapps(cmd *cobra.Command, _ []string) error {
 	}
 
 	header := table.Row{
-		table.HeaderText("apps"),
-		table.HeaderText("name"),
+		table.HeaderText("Display Name"),
+		table.HeaderText("Name"),
+		table.HeaderText("App Port"),
 	}
 
 	rows := make([]table.Row, 0)
 
+	ports := make([]string, 0)
 	for _, a := range apps {
-		rows = append(rows, table.Row{a.DisplayName, a.Metadata.Name})
+		ports = nil
+		for _, v := range a.Spec.Services {
+			ports = append(ports, strconv.Itoa(v.Port))
+		}
+		rows = append(rows, table.Row{a.DisplayName, a.Metadata.Name, strings.Join(ports, ", ")})
 	}
 
 	fn.Println(table.Table(&header, rows, cmd))

--- a/cmd/list/env.go
+++ b/cmd/list/env.go
@@ -50,7 +50,7 @@ func listEnvironments(cmd *cobra.Command, args []string) error {
 		envName = env.Name
 	}
 
-	header := table.Row{table.HeaderText("DisplayName"), table.HeaderText("Name"), table.HeaderText("ready")}
+	header := table.Row{table.HeaderText("Display Name"), table.HeaderText("Name"), table.HeaderText("ready")}
 	rows := make([]table.Row, 0)
 
 	for _, a := range envs {

--- a/cmd/list/mreses.go
+++ b/cmd/list/mreses.go
@@ -46,7 +46,7 @@ var mresCmd = &cobra.Command{
 
 func printMres(_ *cobra.Command, secrets []apiclient.Mres) error {
 	if len(secrets) == 0 {
-		return functions.Error("no secrets found")
+		return functions.Error("no managed resources found")
 	}
 
 	header := table.Row{

--- a/domain/fileclient/environment.go
+++ b/domain/fileclient/environment.go
@@ -97,11 +97,11 @@ func CurrentEnv() (*Env, error) {
 	}
 
 	if c.SelectedEnvs == nil {
-		return nil, fn.Error("no selected environment")
+		return nil, fn.NewE(NoEnvSelected)
 	}
 
 	if c.SelectedEnvs[dir] == nil {
-		return nil, fn.Error("no selected environment")
+		return nil, fn.NewE(NoEnvSelected)
 	}
 
 	return c.SelectedEnvs[dir], nil


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request enhances several commands in the CLI tool. It updates the 'listapps' command to display the application port, improves the 'status' command to handle cases with no selected environment, and adds user confirmation prompts to 'restart', 'stop', and 'start' commands in the 'box' package. Additionally, it introduces a new error type 'UserCanceled' to manage user cancellation scenarios.

- **Enhancements**:
    - Updated the 'listapps' command to include 'App Port' in the output table.
    - Enhanced the 'status' command to handle cases where no environment is selected by providing a default environment from the kl.yml file.
    - Added user confirmation prompts to the 'restart', 'stop', and 'start' commands in the 'box' package to ensure user intent before stopping or restarting containers.
    - Introduced a new error type 'UserCanceled' to handle user cancellation scenarios in container operations.

<!-- Generated by sourcery-ai[bot]: end summary -->