### PR TITLE
wg container will health check and restart

### DIFF
--- a/cmd/box/boxpkg/utils.go
+++ b/cmd/box/boxpkg/utils.go
@@ -520,8 +520,7 @@ func (c *client) generateMounts() ([]mount.Mount, error) {
 
 func (c *client) SyncVpn(wg string) error {
 	defer spinner.Client.UpdateMessage("validating vpn configuration")()
-
-	err := c.ensureImage(constants.WireguardImage)
+	err := c.ensureImage(constants.GetWireguardImageName())
 	if err != nil {
 		return fn.Error("failed to pull image")
 	}
@@ -567,11 +566,14 @@ func (c *client) SyncVpn(wg string) error {
 			"wg":          "true",
 			"wgsum":       fmt.Sprintf("%x", md5sum[:]),
 		},
-		Image: constants.WireguardImage,
+		Image: constants.GetWireguardImageName(),
 		Cmd:   []string{"sh", "-c", script},
 	}, &container.HostConfig{
 		CapAdd:      []string{"NET_ADMIN"},
 		NetworkMode: "host",
+		RestartPolicy: container.RestartPolicy{
+			Name: "always",
+		},
 	}, &network.NetworkingConfig{}, nil, "")
 	if err != nil {
 		return fn.Error("failed to create container")

--- a/cmd/box/boxpkg/utils.go
+++ b/cmd/box/boxpkg/utils.go
@@ -520,6 +520,7 @@ func (c *client) generateMounts() ([]mount.Mount, error) {
 
 func (c *client) SyncVpn(wg string) error {
 	defer spinner.Client.UpdateMessage("validating vpn configuration")()
+
 	err := c.ensureImage(constants.GetWireguardImageName())
 	if err != nil {
 		return fn.Error("failed to pull image")

--- a/constants/main.go
+++ b/constants/main.go
@@ -2,6 +2,7 @@ package constants
 
 import (
 	"fmt"
+	"github.com/kloudlite/kl/flags"
 
 	"github.com/kloudlite/kl/domain/fileclient"
 )
@@ -12,9 +13,13 @@ const (
 	RuntimeDarwin  = "darwin"
 	RuntimeWindows = "windows"
 
-	SocatImage     = "ghcr.io/kloudlite/hub/socat:latest"
-	WireguardImage = "ghcr.io/kloudlite/hub/wireguard:latest"
+	SocatImage = "ghcr.io/kloudlite/hub/socat:latest"
+	//WireguardImage = "ghcr.io/kloudlite/hub/wireguard:latest"
 )
+
+func GetWireguardImageName() string {
+	return fmt.Sprintf("ghcr.io/kloudlite/kl/box/wireguard:%s", flags.Version)
+}
 
 var (
 	BaseURL = func() string {

--- a/constants/main.go
+++ b/constants/main.go
@@ -12,9 +12,7 @@ const (
 	RuntimeLinux   = "linux"
 	RuntimeDarwin  = "darwin"
 	RuntimeWindows = "windows"
-
 	SocatImage = "ghcr.io/kloudlite/hub/socat:latest"
-	//WireguardImage = "ghcr.io/kloudlite/hub/wireguard:latest"
 )
 
 func GetWireguardImageName() string {

--- a/klbox-docker/Taskfile.yml
+++ b/klbox-docker/Taskfile.yml
@@ -42,7 +42,11 @@ tasks:
       - sh: '[[ -n "{{.tag}}" ]]'
         msg: "var tag must have a value, of format 'v1.0.0-nightly'"
     cmds:
+#      - docker buildx create --name klbuilder --use
+#      - docker buildx inspect klbuilder --bootstrap
       - docker buildx build --platform linux/amd64,linux/arm64 -t {{.ImageRegistry}}:{{.tag}} --build-arg VERSION={{.tag}} --build-context project=.. . --push
+#      - docker buildx rm klbuilder
+
       # - docker buildx build -t {{.ImageRegistry}}:{{.tag}} . --push
 
   setup:

--- a/wireguard/Dockerfile
+++ b/wireguard/Dockerfile
@@ -4,4 +4,4 @@ COPY healthcheck.sh /usr/local/bin/healthcheck.sh
 
 RUN chmod +x /usr/local/bin/healthcheck.sh
 
-HEALTHCHECK --interval=10s --timeout=10s --retries=1  CMD /usr/local/bin/healthcheck.sh
+HEALTHCHECK --interval=2s --timeout=2s --retries=1  CMD /usr/local/bin/healthcheck.sh

--- a/wireguard/Dockerfile
+++ b/wireguard/Dockerfile
@@ -1,0 +1,7 @@
+FROM ghcr.io/kloudlite/hub/wireguard:latest
+
+COPY healthcheck.sh /usr/local/bin/healthcheck.sh
+
+RUN chmod +x /usr/local/bin/healthcheck.sh
+
+HEALTHCHECK --interval=10s --timeout=10s --retries=1  CMD /usr/local/bin/healthcheck.sh

--- a/wireguard/Taskfile.yml
+++ b/wireguard/Taskfile.yml
@@ -1,0 +1,18 @@
+version: 3
+
+
+vars:
+  ImageRegistry: "ghcr.io/kloudlite/kl/box/wireguard"
+
+tasks:
+  container:build:
+    cmds:
+      - docker buildx build --build-context project=.. --load -t {{.ImageRegistry}}:v1.0.0-nightly --build-arg VERSION=v1.0.0-nightly .
+
+  container:push:
+    preconditions:
+      - sh: '[[ -n "{{.tag}}" ]]'
+        msg: "var tag must have a value, of format 'v1.0.0-nightly'"
+    cmds:
+      - docker buildx build --platform linux/amd64,linux/arm64 -t {{.ImageRegistry}}:{{.tag}} --build-arg VERSION={{.tag}} --build-context project=.. . --push
+      # - docker buildx build -t {{.ImageRegistry}}:{{.tag}} . --push

--- a/wireguard/Taskfile.yml
+++ b/wireguard/Taskfile.yml
@@ -14,5 +14,8 @@ tasks:
       - sh: '[[ -n "{{.tag}}" ]]'
         msg: "var tag must have a value, of format 'v1.0.0-nightly'"
     cmds:
+#      - docker buildx create --name klbuilder --use
+#      - docker buildx inspect klbuilder --bootstrap
       - docker buildx build --platform linux/amd64,linux/arm64 -t {{.ImageRegistry}}:{{.tag}} --build-arg VERSION={{.tag}} --build-context project=.. . --push
+#      - docker buildx rm klbuilder
       # - docker buildx build -t {{.ImageRegistry}}:{{.tag}} . --push

--- a/wireguard/healthcheck.sh
+++ b/wireguard/healthcheck.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+
+ping 100.64.0.1 -c 1 > /dev/null 2>&1

--- a/wireguard/healthcheck.sh
+++ b/wireguard/healthcheck.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
 
-
-ping 100.64.0.1 -c 1 > /dev/null 2>&1
+# Check if the target IP is reachable
+if ping -c 1 100.64.0.1 > /dev/null 2>&1
+then
+    exit 0  # IP is reachable, healthcheck passes
+else
+    exit 1  # IP is not reachable, healthcheck fails
+fi

--- a/wireguard/healthcheck.sh
+++ b/wireguard/healthcheck.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 
-# Check if the target IP is reachable
 if ping -c 1 100.64.0.1 > /dev/null 2>&1
 then
-    exit 0  # IP is reachable, healthcheck passes
+    exit 0
 else
-    exit 1  # IP is not reachable, healthcheck fails
+    exit 1
 fi


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request enhances the Wireguard container by adding a health check script and a restart policy. It also updates the image name to be dynamically generated and introduces a Taskfile for building and pushing the container image.

- **New Features**:
    - Introduced a health check script for the Wireguard container to ping a specific IP address.
- **Enhancements**:
    - Updated the Wireguard image name to be dynamically generated based on the version.
    - Added a restart policy to the Wireguard container to always restart on failure.
- **Build**:
    - Added a Taskfile for building and pushing the Wireguard container image with support for multiple platforms.

<!-- Generated by sourcery-ai[bot]: end summary -->