### PR TITLE
default env from kl.yml will be considered as current env if no curre…

### DIFF
--- a/cmd/get/config.go
+++ b/cmd/get/config.go
@@ -44,7 +44,7 @@ var configCmd = &cobra.Command{
 				fn.PrintError(err)
 				return
 			}
-			currentEnv, err := fc.CurrentEnv()
+			currentEnv, err := apic.EnsureEnv()
 			if err != nil {
 				fn.PrintError(err)
 				return
@@ -69,7 +69,7 @@ var configCmd = &cobra.Command{
 			fn.PrintError(err)
 			return
 		}
-		currentEnvName, err := fc.CurrentEnv()
+		currentEnvName, err := apic.EnsureEnv()
 		if err != nil {
 			fn.PrintError(err)
 			return

--- a/cmd/get/secret.go
+++ b/cmd/get/secret.go
@@ -44,7 +44,7 @@ var secretCmd = &cobra.Command{
 				fn.PrintError(err)
 				return
 			}
-			currentEnv, err := fc.CurrentEnv()
+			currentEnv, err := apic.EnsureEnv()
 			if err != nil {
 				fn.PrintError(err)
 				return

--- a/cmd/list/acc.go
+++ b/cmd/list/acc.go
@@ -38,7 +38,7 @@ func listAccounts(apic apiclient.ApiClient, cmd *cobra.Command) error {
 	}
 
 	if len(accounts) == 0 {
-		return functions.Error("no accounts found")
+		return fmt.Errorf("[#] no accounts found")
 	}
 
 	fc, err := fileclient.New()

--- a/cmd/list/apps.go
+++ b/cmd/list/apps.go
@@ -1,6 +1,8 @@
 package list
 
 import (
+	"fmt"
+	"github.com/kloudlite/kl/pkg/ui/text"
 	"strconv"
 	"strings"
 
@@ -47,7 +49,7 @@ func listapps(apic apiclient.ApiClient, fc fileclient.FileClient, cmd *cobra.Com
 	if err != nil {
 		return functions.NewE(err)
 	}
-	currentEnvName, err := fc.CurrentEnv()
+	currentEnvName, err := apic.EnsureEnv()
 	if err != nil {
 		return functions.NewE(err)
 	}
@@ -58,7 +60,7 @@ func listapps(apic apiclient.ApiClient, fc fileclient.FileClient, cmd *cobra.Com
 	}
 
 	if len(apps) == 0 {
-		return functions.Error("no apps found")
+		return fmt.Errorf("[#] no apps found in environemnt: %s", text.Blue(currentEnvName.Name))
 	}
 
 	header := table.Row{

--- a/cmd/list/configs.go
+++ b/cmd/list/configs.go
@@ -34,7 +34,7 @@ var configsCmd = &cobra.Command{
 			fn.PrintError(err)
 			return
 		}
-		currentEnv, err := fc.CurrentEnv()
+		currentEnv, err := apic.EnsureEnv()
 		if err != nil {
 			fn.PrintError(err)
 			return
@@ -46,15 +46,15 @@ var configsCmd = &cobra.Command{
 			return
 		}
 
-		if err := printConfigs(fc, cmd, config); err != nil {
+		if err := printConfigs(apic, cmd, config); err != nil {
 			fn.PrintError(err)
 			return
 		}
 	},
 }
 
-func printConfigs(fc fileclient.FileClient, cmd *cobra.Command, configs []apiclient.Config) error {
-	e, err := fc.CurrentEnv()
+func printConfigs(apic apiclient.ApiClient, cmd *cobra.Command, configs []apiclient.Config) error {
+	e, err := apic.EnsureEnv()
 	if err != nil {
 		return fn.NewE(err)
 	}

--- a/cmd/list/env.go
+++ b/cmd/list/env.go
@@ -2,6 +2,7 @@ package list
 
 import (
 	"fmt"
+	"github.com/kloudlite/kl/pkg/ui/text"
 
 	"github.com/kloudlite/kl/domain/apiclient"
 	"github.com/kloudlite/kl/domain/fileclient"
@@ -46,10 +47,10 @@ func listEnvironments(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(envs) == 0 {
-		return functions.Error("no environments found")
+		return fmt.Errorf("[#] no environments found in account: %s", text.Blue(currentAccount))
 	}
 
-	env, _ := fc.CurrentEnv()
+	env, _ := apic.EnsureEnv()
 	envName := ""
 	if env != nil {
 		envName = env.Name

--- a/cmd/list/secrets.go
+++ b/cmd/list/secrets.go
@@ -2,6 +2,7 @@ package list
 
 import (
 	"fmt"
+	"github.com/kloudlite/kl/pkg/ui/text"
 
 	"github.com/kloudlite/kl/domain/fileclient"
 
@@ -35,7 +36,7 @@ var secretsCmd = &cobra.Command{
 			fn.PrintError(err)
 			return
 		}
-		currentEnv, err := fc.CurrentEnv()
+		currentEnv, err := apic.EnsureEnv()
 		if err != nil {
 			fn.PrintError(err)
 			return
@@ -47,16 +48,21 @@ var secretsCmd = &cobra.Command{
 			return
 		}
 
-		if err := printSecrets(cmd, sec); err != nil {
+		if err := printSecrets(apic, cmd, sec); err != nil {
 			fn.PrintError(err)
 			return
 		}
 	},
 }
 
-func printSecrets(_ *cobra.Command, secrets []apiclient.Secret) error {
+func printSecrets(apic apiclient.ApiClient, cmd *cobra.Command, secrets []apiclient.Secret) error {
+	e, err := apic.EnsureEnv()
+	if err != nil {
+		return fn.NewE(err)
+	}
+
 	if len(secrets) == 0 {
-		return fn.Error("no secrets found")
+		return fmt.Errorf("[#] no secrets found in environemnt: %s", text.Blue(e.Name))
 	}
 
 	header := table.Row{

--- a/cmd/runner/add/add-config.go
+++ b/cmd/runner/add/add-config.go
@@ -64,7 +64,7 @@ func selectAndAddConfig(cmd *cobra.Command, args []string) error {
 		return fn.NewE(err)
 	}
 
-	currentEnv, err := fc.CurrentEnv()
+	currentEnv, err := apic.EnsureEnv()
 	if err != nil {
 		return fn.NewE(err)
 	}

--- a/cmd/runner/add/add-mres.go
+++ b/cmd/runner/add/add-mres.go
@@ -139,7 +139,7 @@ func AddMres(apic apiclient.ApiClient, fc fileclient.FileClient, cmd *cobra.Comm
 }
 
 func selectMres(apic apiclient.ApiClient, fc fileclient.FileClient) (*apiclient.Mres, error) {
-	currentEnv, err := fc.CurrentEnv()
+	currentEnv, err := apic.EnsureEnv()
 	if err != nil {
 		return nil, fn.NewE(err)
 	}

--- a/cmd/runner/add/add-secret.go
+++ b/cmd/runner/add/add-secret.go
@@ -62,7 +62,7 @@ func selectAndAddSecret(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fn.NewE(err)
 	}
-	currentEnv, err := fc.CurrentEnv()
+	currentEnv, err := apic.EnsureEnv()
 	if err != nil {
 		return fn.NewE(err)
 	}

--- a/cmd/runner/add/mount.go
+++ b/cmd/runner/add/mount.go
@@ -104,7 +104,7 @@ func selectConfigMount(apic apiclient.ApiClient, fc fileclient.FileClient, path 
 		if err != nil {
 			return err
 		}
-		currentEnv, err := fc.CurrentEnv()
+		currentEnv, err := apic.EnsureEnv()
 		if err != nil {
 			fn.PrintError(err)
 			return err
@@ -127,7 +127,7 @@ func selectConfigMount(apic apiclient.ApiClient, fc fileclient.FileClient, path 
 		if err != nil {
 			return err
 		}
-		currentEnv, err := fc.CurrentEnv()
+		currentEnv, err := apic.EnsureEnv()
 		if err != nil {
 			fn.PrintError(err)
 			return err

--- a/cmd/status/status.go
+++ b/cmd/status/status.go
@@ -43,7 +43,7 @@ var Cmd = &cobra.Command{
 			fn.Log(fmt.Sprint(text.Bold(text.Blue("Account: ")), acc))
 		}
 
-		e, err := fc.CurrentEnv()
+		e, err := apic.EnsureEnv()
 		if err == nil {
 			fn.Log(fmt.Sprint(text.Bold(text.Blue("Environment: ")), e.Name))
 		} else if errors.Is(err, fileclient.NoEnvSelected) {

--- a/cmd/use/env.go
+++ b/cmd/use/env.go
@@ -114,7 +114,7 @@ func selectEnv(apic apiclient.ApiClient, fc fileclient.FileClient) (*apiclient.E
 		return nil, functions.NewE(err)
 	}
 
-	oldEnv, _ := fc.CurrentEnv()
+	oldEnv, _ := apic.EnsureEnv()
 
 	env, err := fzf.FindOne(
 		envs,

--- a/domain/apiclient/app.go
+++ b/domain/apiclient/app.go
@@ -194,7 +194,7 @@ func (apic *apiClient) RemoveAllIntercepts(options ...fn.Option) error {
 	defer spinner.Client.UpdateMessage("Cleaning up intercepts...")()
 	devName := fn.GetOption(options, "deviceName")
 	accountName := fn.GetOption(options, "accountName")
-	currentEnv, err := apic.fc.CurrentEnv()
+	currentEnv, err := apic.EnsureEnv()
 	if err != nil {
 		return functions.NewE(err)
 	}

--- a/domain/apiclient/generateEnv.go
+++ b/domain/apiclient/generateEnv.go
@@ -86,7 +86,7 @@ func (apic *apiClient) GetLoadMaps() (map[string]string, MountMap, error) {
 		return nil, nil, functions.NewE(err)
 	}
 
-	env, err := fc.CurrentEnv()
+	env, err := apic.EnsureEnv()
 	if err != nil {
 		return nil, nil, functions.NewE(err)
 	}

--- a/domain/apiclient/impl.go
+++ b/domain/apiclient/impl.go
@@ -28,6 +28,7 @@ type ApiClient interface {
 
 	ListEnvs(accountName string) ([]Env, error)
 	GetEnvironment(accountName, envName string) (*Env, error)
+	EnsureEnv() (*fileclient.Env, error)
 	GetLoadMaps() (map[string]string, MountMap, error)
 
 	ListMreses(accountName string, envName string) ([]Mres, error)

--- a/domain/apiclient/mres.go
+++ b/domain/apiclient/mres.go
@@ -65,7 +65,7 @@ type MresResp struct {
 func (apic *apiClient) GetMresConfigValues(accountName string) (map[string]string, error) {
 	fc := apic.fc
 
-	currentEnv, err := fc.CurrentEnv()
+	currentEnv, err := apic.EnsureEnv()
 	if err != nil {
 		return nil, fn.NewE(err)
 	}

--- a/domain/apiclient/secrets.go
+++ b/domain/apiclient/secrets.go
@@ -108,7 +108,7 @@ func (apic *apiClient) GetSecret(accountName string, secretName string) (*Secret
 		return nil, fn.NewE(err)
 	}
 
-	currentEnv, err := apic.fc.CurrentEnv()
+	currentEnv, err := apic.EnsureEnv()
 	if err != nil {
 		return nil, fn.NewE(err)
 	}


### PR DESCRIPTION
…nt env is selected

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Refactored multiple commands to use the new `EnsureEnv` method, ensuring that the default environment from `kl.yml` is considered if no current environment is selected. This change affects various commands related to listing and managing resources, secrets, configs, and environments.

- **Enhancements**:
    - Introduced a new method `EnsureEnv` in the `apiClient` to ensure that the current environment is set, defaulting to the environment specified in `kl.yml` if no current environment is selected.

<!-- Generated by sourcery-ai[bot]: end summary -->