### PR TITLE
Ci/testing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,12 @@ name: Release
 on:
   workflow_dispatch:
 
-  # release:
-  #   types: [created]
-  #
-  # push:
-  #   branches:
-  #     - 'release-*'
+  release:
+    types: [created]
+
+  push:
+    branches:
+      - 'release-*'
 
 jobs:
   docker-build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,9 +56,11 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build & Push Image
-        if: startsWith(github.ref, 'refs/heads/release-') || startsWith(github.ref, 'refs/tags/')
+        # if: startsWith(github.ref, 'refs/heads/release-') || startsWith(github.ref, 'refs/tags/')
         env:
-          IMAGE_TAG: ${{ steps.tag_name.outputs.TAG_NAME }}
+          #IMAGE_TAG: ${{ steps.tag_name.outputs.TAG_NAME }}
+          # IMAGE_TAG: v1.0.7-nightly
+          IMAGE_TAG: ci-testing
           OVERRIDE_PUSHED_IMAGE: "false"
         run: |
           set +e


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the CI release workflow to support multi-architecture Docker builds and manifests, and enable triggering on specific release events.

CI:
- Enable the release workflow to trigger on release creation and push events to branches matching 'release-*'.
- Introduce a matrix strategy for the 'klbox-docker-build' job to support both amd64 and arm64 architectures.
- Add a new job 'klbox-docker-multiarch-manifest' to create and push multi-architecture Docker manifests.

<!-- Generated by sourcery-ai[bot]: end summary -->