### PR TITLE
environment cloning implemented

### DIFF
--- a/clis/kl/loadsubs.go
+++ b/clis/kl/loadsubs.go
@@ -3,6 +3,7 @@ package kl
 import (
 	"github.com/kloudlite/kl/cmd/auth"
 	"github.com/kloudlite/kl/cmd/box"
+	"github.com/kloudlite/kl/cmd/clone"
 	"github.com/kloudlite/kl/cmd/expose"
 	"github.com/kloudlite/kl/cmd/get"
 	"github.com/kloudlite/kl/cmd/list"
@@ -34,6 +35,7 @@ func init() {
 	rootCmd.AddCommand(box.BoxCmd)
 
 	rootCmd.AddCommand(use.Cmd)
+	rootCmd.AddCommand(clone.Cmd)
 	rootCmd.AddCommand(runner.InitCommand)
 	rootCmd.AddCommand(set_base_url.Cmd)
 

--- a/cmd/clone/clone.go
+++ b/cmd/clone/clone.go
@@ -1,0 +1,12 @@
+package clone
+
+import "github.com/spf13/cobra"
+
+var Cmd = &cobra.Command{
+	Use:   "clone",
+	Short: "clone environment from current environment",
+}
+
+func init() {
+	Cmd.AddCommand(cloneCmd)
+}

--- a/cmd/clone/env.go
+++ b/cmd/clone/env.go
@@ -1,0 +1,171 @@
+package clone
+
+import (
+	"fmt"
+	"github.com/kloudlite/kl/cmd/box/boxpkg"
+	"github.com/kloudlite/kl/cmd/box/boxpkg/hashctrl"
+	"github.com/kloudlite/kl/domain/apiclient"
+	"github.com/kloudlite/kl/domain/fileclient"
+	fn "github.com/kloudlite/kl/pkg/functions"
+	"github.com/kloudlite/kl/pkg/ui/fzf"
+	"github.com/kloudlite/kl/pkg/ui/text"
+	"github.com/spf13/cobra"
+	"os"
+)
+
+var cloneCmd = &cobra.Command{
+	Use:   "env",
+	Short: "Switch to a different environment",
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := envClone(cmd, args); err != nil {
+			fn.PrintError(err)
+			return
+		}
+	},
+}
+
+func envClone(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		return fn.Error("env name is required")
+	}
+	envName := args[0]
+
+	fc, err := fileclient.New()
+	if err != nil {
+		return err
+	}
+
+	apic, err := apiclient.New()
+	if err != nil {
+		return err
+	}
+
+	klFile, err := fc.GetKlFile("")
+	if err != nil {
+		return err
+	}
+
+	isValidName, err := checkEnvNameAvailability(apic, fc, envName)
+	if err != nil {
+		return err
+	}
+
+	if !isValidName {
+		return fn.Error("env name is not available")
+	}
+
+	cluster, err := selectCluster(apic, fc)
+	if err != nil {
+		return err
+	}
+	env, err := cloneEnv(apic, fc, envName, cluster.Metadata.Name)
+	if err != nil {
+		return err
+	}
+
+	if klFile.DefaultEnv == "" {
+		klFile.DefaultEnv = env.Metadata.Name
+		if err := fc.WriteKLFile(*klFile); err != nil {
+			return err
+		}
+	}
+	fn.Log(text.Bold(text.Green("\nSelected Environment:")),
+		text.Blue(fmt.Sprintf("\n%s (%s)", env.DisplayName, env.Metadata.Name)),
+	)
+
+	wpath, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	if err := hashctrl.SyncBoxHash(apic, fc, wpath); err != nil {
+		return err
+	}
+
+	c, err := boxpkg.NewClient(cmd, nil)
+	if err != nil {
+		return err
+	}
+
+	if err := c.ConfirmBoxRestart(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func cloneEnv(apic apiclient.ApiClient, fc fileclient.FileClient, newEnvName string, clusterName string) (*apiclient.Env, error) {
+	currentAccount, err := fc.CurrentAccountName()
+	if err != nil {
+		return nil, fn.NewE(err)
+	}
+
+	oldEnv, err := apic.EnsureEnv()
+	if err != nil {
+		return nil, fn.NewE(err)
+	}
+
+	env, err := apic.CloneEnv(currentAccount, oldEnv.Name, newEnvName, clusterName)
+	if err != nil {
+		return nil, fn.NewE(err)
+	}
+	err = apic.RemoveAllIntercepts()
+	if err != nil {
+		return nil, fn.NewE(err)
+	}
+
+	persistSelectedEnv := func(e fileclient.Env) error {
+		err := fc.SelectEnv(e)
+		if err != nil {
+			return fn.NewE(err)
+		}
+		return nil
+	}
+
+	if err := persistSelectedEnv(fileclient.Env{
+		Name: env.Metadata.Name,
+		SSHPort: func() int {
+			if oldEnv == nil {
+				return 0
+			}
+			return oldEnv.SSHPort
+		}(),
+	}); err != nil {
+		return nil, fn.NewE(err)
+	}
+	return env, nil
+}
+
+func selectCluster(apic apiclient.ApiClient, fc fileclient.FileClient) (*apiclient.BYOKCluster, error) {
+	currentAccount, err := fc.CurrentAccountName()
+	if err != nil {
+		return nil, fn.NewE(err)
+	}
+
+	clusters, err := apic.ListBYOKClusters(currentAccount)
+	if err != nil {
+		return nil, fn.NewE(err)
+	}
+
+	cluster, err := fzf.FindOne(
+		clusters,
+		func(clus apiclient.BYOKCluster) string {
+			return fmt.Sprintf("%s (%s)", clus.DisplayName, clus.Metadata.Name)
+		},
+		fzf.WithPrompt("Select Cluster > "),
+	)
+
+	if err != nil {
+		return nil, fn.NewE(err)
+	}
+
+	return cluster, nil
+
+}
+
+func checkEnvNameAvailability(apic apiclient.ApiClient, fc fileclient.FileClient, envName string) (bool, error) {
+	currentAccount, err := fc.CurrentAccountName()
+	if err != nil {
+		return false, fn.NewE(err)
+	}
+
+	return apic.CheckEnvName(currentAccount, envName)
+}

--- a/cmd/use/use.go
+++ b/cmd/use/use.go
@@ -4,7 +4,7 @@ import "github.com/spf13/cobra"
 
 var Cmd = &cobra.Command{
 	Use:   "use",
-	Short: "select environment and account to current context",
+	Short: "select environment to current context",
 }
 
 func init() {

--- a/domain/apiclient/clusters.go
+++ b/domain/apiclient/clusters.go
@@ -1,0 +1,35 @@
+package apiclient
+
+import (
+	fn "github.com/kloudlite/kl/pkg/functions"
+)
+
+type BYOKCluster struct {
+	DisplayName string   `json:"displayName"`
+	Metadata    Metadata `json:"metadata"`
+}
+
+func (apic *apiClient) ListBYOKClusters(accountName string) ([]BYOKCluster, error) {
+	cookie, err := getCookie(fn.MakeOption("accountName", accountName))
+	if err != nil {
+		return nil, fn.NewE(err)
+	}
+
+	respData, err := klFetch("cli_listByokClusters", map[string]any{
+		"pq": map[string]any{
+			"orderBy":       "updateTime",
+			"sortDirection": "ASC",
+			"first":         99999999,
+		},
+	}, &cookie)
+
+	if err != nil {
+		return nil, fn.NewE(err)
+	}
+
+	if fromResp, err := GetFromRespForEdge[BYOKCluster](respData); err != nil {
+		return nil, fn.NewE(err)
+	} else {
+		return fromResp, fn.NewE(err)
+	}
+}

--- a/domain/apiclient/impl.go
+++ b/domain/apiclient/impl.go
@@ -29,7 +29,11 @@ type ApiClient interface {
 	ListEnvs(accountName string) ([]Env, error)
 	GetEnvironment(accountName, envName string) (*Env, error)
 	EnsureEnv() (*fileclient.Env, error)
+	CloneEnv(accountName, envName, newEnvName, clusterName string) (*Env, error)
+	CheckEnvName(accountName, envName string) (bool, error)
 	GetLoadMaps() (map[string]string, MountMap, error)
+
+	ListBYOKClusters(accountName string) ([]BYOKCluster, error)
 
 	ListMreses(accountName string, envName string) ([]Mres, error)
 	ListMresKeys(accountName, envName, importedManagedResource string) ([]string, error)


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Implement environment cloning feature with a new CLI command, allowing users to clone and switch environments. Add methods to check environment name availability and list BYOK clusters, enhancing the environment management capabilities.

New Features:
- Implement environment cloning functionality, allowing users to clone an existing environment to a new one.
- Add a command-line interface command for cloning environments, enabling users to switch to a different environment.
- Introduce a method to check the availability of environment names to ensure uniqueness before cloning.
- Add functionality to list BYOK (Bring Your Own Key) clusters, which can be used during the environment cloning process.

Enhancements:
- Update the command description for the 'use' command to reflect its functionality more accurately.

<!-- Generated by sourcery-ai[bot]: end summary -->