### PR TITLE
connect command added to start the wireguard container

### DIFF
--- a/clis/kl/loadsubs.go
+++ b/clis/kl/loadsubs.go
@@ -4,6 +4,7 @@ import (
 	"github.com/kloudlite/kl/cmd/auth"
 	"github.com/kloudlite/kl/cmd/box"
 	"github.com/kloudlite/kl/cmd/clone"
+	"github.com/kloudlite/kl/cmd/connect"
 	"github.com/kloudlite/kl/cmd/expose"
 	"github.com/kloudlite/kl/cmd/get"
 	"github.com/kloudlite/kl/cmd/list"
@@ -33,6 +34,7 @@ func init() {
 	rootCmd.AddCommand(get.Cmd)
 	rootCmd.AddCommand(auth.Cmd)
 	rootCmd.AddCommand(box.BoxCmd)
+	rootCmd.AddCommand(connect.Command)
 
 	rootCmd.AddCommand(use.Cmd)
 	rootCmd.AddCommand(clone.Cmd)

--- a/cmd/box/boxpkg/main.go
+++ b/cmd/box/boxpkg/main.go
@@ -47,6 +47,7 @@ type BoxClient interface {
 	Exec([]string, io.Writer) error
 
 	ConfirmBoxRestart() error
+	StartWgContainer() error
 }
 
 func (c *client) Context() context.Context {

--- a/cmd/box/boxpkg/start.go
+++ b/cmd/box/boxpkg/start.go
@@ -70,13 +70,9 @@ func (c *client) Start() error {
 		return fn.NewE(err)
 	}
 
-	vpnCfg, err := c.apic.GetAccVPNConfig(c.klfile.AccountName)
+	err = c.StartWgContainer()
 	if err != nil {
-		return functions.NewE(err)
-	}
-
-	if err = c.SyncVpn(vpnCfg.WGconf); err != nil {
-		return functions.NewE(err)
+		return fn.NewE(err)
 	}
 
 	if c.env.SSHPort == 0 {
@@ -117,5 +113,18 @@ func (c *client) Start() error {
 
 	fn.Logf("%s %s %s\n", text.Bold("command:"), text.Blue("ssh"), text.Blue(strings.Join([]string{fmt.Sprintf("kl@%s", getDomainFromPath(c.cwd)), "-p", fmt.Sprint(c.env.SSHPort), "-oStrictHostKeyChecking=no"}, " ")))
 
+	return nil
+}
+
+func (c *client) StartWgContainer() error {
+	defer spinner.Client.UpdateMessage("starting wireguard")()
+	vpnCfg, err := c.apic.GetAccVPNConfig(c.klfile.AccountName)
+	if err != nil {
+		return fn.NewE(err)
+	}
+
+	if err = c.SyncVpn(vpnCfg.WGconf); err != nil {
+		return fn.NewE(err)
+	}
 	return nil
 }

--- a/cmd/connect/connect.go
+++ b/cmd/connect/connect.go
@@ -1,0 +1,68 @@
+package connect
+
+import (
+	"context"
+	"fmt"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
+	dockerclient "github.com/docker/docker/client"
+	"github.com/kloudlite/kl/cmd/box/boxpkg"
+	fn "github.com/kloudlite/kl/pkg/functions"
+	"github.com/spf13/cobra"
+)
+
+var Command = &cobra.Command{
+	Use:   "connect",
+	Short: "start the wireguard connection",
+	Long:  "This command will start the wireguard connection",
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := startWg(cmd, args); err != nil {
+			fn.PrintError(err)
+			return
+		}
+	},
+}
+
+func startWg(cmd *cobra.Command, args []string) error {
+
+	c, err := dockerclient.NewClientWithOpts(dockerclient.FromEnv, dockerclient.WithAPIVersionNegotiation())
+	if err != nil {
+		return fn.NewE(err)
+	}
+	existingContainers, err := c.ContainerList(context.Background(), container.ListOptions{
+		All: true,
+		Filters: filters.NewArgs(
+			filters.Arg("label", fmt.Sprintf("%s=%s", boxpkg.CONT_MARK_KEY, "true")),
+			filters.Arg("label", fmt.Sprintf("%s=%s", "wg", "true")),
+		),
+	})
+	if err != nil {
+		return fn.NewE(err)
+	}
+
+	if len(existingContainers) != 0 {
+		containerID := existingContainers[0].ID
+		timeOut := 0
+
+		if err := c.ContainerStop(context.Background(), containerID, container.StopOptions{
+			Timeout: &timeOut,
+		}); err != nil {
+			return fn.NewE(fmt.Errorf("failed to stop container: %w", err))
+		}
+
+		if err := c.ContainerStart(context.Background(), containerID, container.StartOptions{}); err != nil {
+			return fn.NewE(fmt.Errorf("failed to start container: %w", err))
+		}
+		return nil
+	}
+
+	boxClient, err := boxpkg.NewClient(cmd, args)
+	if err != nil {
+		return fn.NewE(err)
+	}
+	err = boxClient.StartWgContainer()
+	if err != nil {
+		return fn.NewE(err)
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add a new 'connect' command to manage the WireGuard connection by starting the WireGuard container. Refactor existing logic to encapsulate the WireGuard container start process in a dedicated method.

New Features:
- Introduce a new 'connect' command to start the WireGuard connection, which manages the WireGuard container lifecycle.

Enhancements:
- Refactor the WireGuard container start logic into a separate method 'StartWgContainer' within the client interface.

<!-- Generated by sourcery-ai[bot]: end summary -->