### PR TITLE
connect cmd removed

### DIFF
--- a/clis/kl/loadsubs.go
+++ b/clis/kl/loadsubs.go
@@ -4,7 +4,6 @@ import (
 	"github.com/kloudlite/kl/cmd/auth"
 	"github.com/kloudlite/kl/cmd/box"
 	"github.com/kloudlite/kl/cmd/clone"
-	"github.com/kloudlite/kl/cmd/connect"
 	"github.com/kloudlite/kl/cmd/expose"
 	"github.com/kloudlite/kl/cmd/get"
 	"github.com/kloudlite/kl/cmd/intercept"
@@ -35,7 +34,7 @@ func init() {
 	rootCmd.AddCommand(get.Cmd)
 	rootCmd.AddCommand(auth.Cmd)
 	rootCmd.AddCommand(box.BoxCmd)
-	rootCmd.AddCommand(connect.Command)
+	//rootCmd.AddCommand(connect.Command)
 
 	rootCmd.AddCommand(use.Cmd)
 	rootCmd.AddCommand(clone.Cmd)

--- a/clis/kl/loadsubs.go
+++ b/clis/kl/loadsubs.go
@@ -34,7 +34,9 @@ func init() {
 	rootCmd.AddCommand(get.Cmd)
 	rootCmd.AddCommand(auth.Cmd)
 	rootCmd.AddCommand(box.BoxCmd)
-	//rootCmd.AddCommand(connect.Command)
+	rootCmd.AddCommand(auth.Cmd)
+	rootCmd.AddCommand(box.BoxCmd)
+	rootCmd.AddCommand(use.Cmd)
 
 	rootCmd.AddCommand(use.Cmd)
 	rootCmd.AddCommand(clone.Cmd)

--- a/cmd/connect/connect.go
+++ b/cmd/connect/connect.go
@@ -1,13 +1,8 @@
 package connect
 
 import (
-	"context"
-	"fmt"
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/filters"
-	dockerclient "github.com/docker/docker/client"
-	"github.com/kloudlite/kl/cmd/box/boxpkg"
 	fn "github.com/kloudlite/kl/pkg/functions"
+	"github.com/kloudlite/kl/pkg/k3s"
 	"github.com/spf13/cobra"
 )
 
@@ -15,54 +10,19 @@ var Command = &cobra.Command{
 	Use:   "connect",
 	Short: "start the wireguard connection",
 	Long:  "This command will start the wireguard connection",
-	Run: func(cmd *cobra.Command, args []string) {
-		if err := startWg(cmd, args); err != nil {
+	Run: func(_ *cobra.Command, _ []string) {
+		if err := startWg(); err != nil {
 			fn.PrintError(err)
 			return
 		}
 	},
 }
 
-func startWg(cmd *cobra.Command, args []string) error {
-
-	c, err := dockerclient.NewClientWithOpts(dockerclient.FromEnv, dockerclient.WithAPIVersionNegotiation())
+func startWg() error {
+	k3s, err := k3s.NewClient()
 	if err != nil {
-		return fn.NewE(err)
-	}
-	existingContainers, err := c.ContainerList(context.Background(), container.ListOptions{
-		All: true,
-		Filters: filters.NewArgs(
-			filters.Arg("label", fmt.Sprintf("%s=%s", boxpkg.CONT_MARK_KEY, "true")),
-			filters.Arg("label", fmt.Sprintf("%s=%s", "wg", "true")),
-		),
-	})
-	if err != nil {
-		return fn.NewE(err)
+		return err
 	}
 
-	if len(existingContainers) != 0 {
-		containerID := existingContainers[0].ID
-		timeOut := 0
-
-		if err := c.ContainerStop(context.Background(), containerID, container.StopOptions{
-			Timeout: &timeOut,
-		}); err != nil {
-			return fn.NewE(fmt.Errorf("failed to stop container: %w", err))
-		}
-
-		if err := c.ContainerStart(context.Background(), containerID, container.StartOptions{}); err != nil {
-			return fn.NewE(fmt.Errorf("failed to start container: %w", err))
-		}
-		return nil
-	}
-
-	boxClient, err := boxpkg.NewClient(cmd, args)
-	if err != nil {
-		return fn.NewE(err)
-	}
-	err = boxClient.StartWgContainer()
-	if err != nil {
-		return fn.NewE(err)
-	}
-	return nil
+	return k3s.RestartWgProxyContainer()
 }

--- a/cmd/get/config.go
+++ b/cmd/get/config.go
@@ -55,7 +55,7 @@ var configCmd = &cobra.Command{
 				return
 			}
 			if len(configs) == 0 {
-				fn.PrintError(fn.Error("no configs created yet on server"))
+fn.PrintError(fn.Error("no configs found"))
 				return
 			}
 			selectedConfig, err := fzf.FindOne(configs, func(config apiclient.Config) string {

--- a/cmd/get/config.go
+++ b/cmd/get/config.go
@@ -54,6 +54,10 @@ var configCmd = &cobra.Command{
 				fn.PrintError(err)
 				return
 			}
+			if len(configs) == 0 {
+				fn.PrintError(fn.Error("no configs created yet on server"))
+				return
+			}
 			selectedConfig, err := fzf.FindOne(configs, func(config apiclient.Config) string {
 				return config.DisplayName
 			}, fzf.WithPrompt("select config > "))

--- a/cmd/get/secret.go
+++ b/cmd/get/secret.go
@@ -54,6 +54,10 @@ var secretCmd = &cobra.Command{
 				fn.PrintError(err)
 				return
 			}
+			if len(secrets) == 0 {
+				fn.PrintError(fn.Error("no secrets created yet on server"))
+				return
+			}
 			selectedSecret, err := fzf.FindOne(secrets, func(secret apiclient.Secret) string {
 				return secret.Metadata.Name
 			}, fzf.WithPrompt("select secret > "))

--- a/pkg/k3s/impl.go
+++ b/pkg/k3s/impl.go
@@ -352,6 +352,15 @@ kubectl apply -f /tmp/service-device-router.yml
 	return c.runScriptInContainer(script.String())
 }
 
+func (c *client) RestartWgProxyContainer() error {
+	defer spinner.Client.UpdateMessage("restarting kloudlite-gateway")()
+	script := `
+kubectl delete pod $(kubectl get pods -n kl-gateway | grep -i default- | awk '{print $1}') -n kl-gateway
+kubectl delete pod $(kubectl get pods -n wg-proxy | grep -i default- | awk '{print $1}') -n wg-proxy
+`
+	return c.runScriptInContainer(script)
+}
+
 func (c *client) runScriptInContainer(script string) error {
 	existingContainers, err := c.c.ContainerList(context.Background(), container.ListOptions{
 		All: true,
@@ -365,7 +374,7 @@ func (c *client) runScriptInContainer(script string) error {
 	}
 
 	if len(existingContainers) == 0 {
-		return fmt.Errorf("no containers found")
+		return fmt.Errorf("no k3s container found")
 	}
 
 	execID, err := c.c.ContainerExecCreate(context.Background(), existingContainers[0].ID, container.ExecOptions{

--- a/pkg/k3s/main.go
+++ b/pkg/k3s/main.go
@@ -11,6 +11,7 @@ type K3sClient interface {
 	EnsureKloudliteNetwork() error
 	StartAppInterceptService(ports []apiclient.AppPort) error
 	EnsureImage(i string) error
+	RestartWgProxyContainer() error
 }
 
 type client struct {


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Remove the connect command and refactor the startWg function to use the new RestartWgProxyContainer method, simplifying the process of restarting the WireGuard proxy container. Add error handling for cases where no configurations or secrets are found on the server.

Enhancements:
- Simplify the startWg function by removing Docker client operations and replacing them with a call to the new RestartWgProxyContainer method.

Chores:
- Remove the connect command from the command-line interface, including its registration in the loadsubs.go file.

<!-- Generated by sourcery-ai[bot]: end summary -->