### PR TITLE
wiregaurd configuration updated

### DIFF
--- a/pkg/k3s/impl.go
+++ b/pkg/k3s/impl.go
@@ -128,9 +128,9 @@ func (c *client) CreateClustersAccounts(accountName string) error {
 					HostPort: "6443",
 				},
 			},
-			"51820/udp": {
+			"33820/udp": {
 				{
-					HostPort: "51820",
+					HostPort: "33820",
 				},
 			},
 		},


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the WireGuard configuration by changing the UDP port from 51820 to 33820 in the deployment settings.

Deployment:
- Update WireGuard configuration to change the UDP port from 51820 to 33820.

<!-- Generated by sourcery-ai[bot]: end summary -->