### PR TITLE
restart wireguard proxy script updated

### DIFF
--- a/domain/fileclient/context.go
+++ b/domain/fileclient/context.go
@@ -30,7 +30,7 @@ const (
 	KLHostIp      = "198.18.0.2"
 	KLWorkspaceIp = "198.18.0.3"
 	KLWGAllowedIp = "100.64.0.0/10"
-	HostIp        = "172.18.0.2"
+	LocalHostIP   = "127.0.0.1"
 )
 
 type Keys struct {
@@ -267,7 +267,7 @@ PublicKey = %s
 AllowedIPs = %s/32, %s
 PersistentKeepalive = 25
 Endpoint = %s:33820
-`, config.Host.PrivateKey, KLHostIp, config.Proxy.PublicKey, KLWGProxyIp, KLWGAllowedIp, HostIp)
+`, config.Host.PrivateKey, KLHostIp, config.Proxy.PublicKey, KLWGProxyIp, KLWGAllowedIp, LocalHostIP)
 	return wgConfig, nil
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Update the WireGuard proxy restart script to delete the pod instead of restarting the interface, and ensure the K3s server is ready post-operation. Improve code clarity by renaming constants and updating spinner messages.

Enhancements:
- Update the spinner message in the EnsureK3sServerIsReady function to provide a more accurate description of the process.
- Modify the RestartWgProxyContainer function to delete the pod instead of restarting the WireGuard interface, and ensure the K3s server is ready after the operation.

Chores:
- Rename the HostIp constant to LocalHostIP for clarity and update its value to '127.0.0.1'.