### PR TITLE
:lock: updated ssh client for insecure-ignore-host-key-use

### DIFF
--- a/pkg/functions/print.go
+++ b/pkg/functions/print.go
@@ -81,6 +81,12 @@ func Printf(format string, str ...interface{}) {
 }
 
 func Println(str ...interface{}) {
-	str = append(str, "\n")
-	stdout(fmt.Sprint(str...))
+	r := strings.Join(func() []string {
+		resp := make([]string, 0, len(str))
+		for _, s := range str {
+			resp = append(resp, fmt.Sprint(s))
+		}
+		return resp
+	}(), " ")
+	stdout(fmt.Sprintf("%s\n", r))
 }

--- a/pkg/sshclient/ssh.go
+++ b/pkg/sshclient/ssh.go
@@ -28,7 +28,7 @@ func HostKeyCallback(hostname string, remote net.Addr, key ssh.PublicKey) error 
 	matches := re.FindStringSubmatch(hostname)
 
 	if len(matches) != 3 {
-		return fn.Errorf("hostname does not allowed to be used: %s", hostname)
+		return fn.Errorf("hostname not allowed: %s", hostname)
 	}
 
 	return nil

--- a/pkg/sshclient/ssh.go
+++ b/pkg/sshclient/ssh.go
@@ -2,7 +2,9 @@ package sshclient
 
 import (
 	"fmt"
+	"net"
 	"os"
+	"regexp"
 
 	fn "github.com/kloudlite/kl/pkg/functions"
 	"github.com/kloudlite/kl/pkg/ui/text"
@@ -18,6 +20,20 @@ type SSHConfig struct {
 	SSHPort int
 }
 
+func HostKeyCallback(hostname string, remote net.Addr, key ssh.PublicKey) error {
+	// *.local.khost.dev:21708
+	// regex match
+
+	re := regexp.MustCompile(`(.*)\.local\.khost\.dev:(\d+)`)
+	matches := re.FindStringSubmatch(hostname)
+
+	if len(matches) != 3 {
+		return fn.Errorf("hostname does not allowed to be used: %s", hostname)
+	}
+
+	return nil
+}
+
 func DoSSH(sc SSHConfig) error {
 	pkFile, err := publicKeyFile(sc.KeyPath)
 
@@ -26,7 +42,7 @@ func DoSSH(sc SSHConfig) error {
 		Auth: []ssh.AuthMethod{
 			pkFile,
 		},
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		HostKeyCallback: HostKeyCallback,
 	}
 
 	client, err := ssh.Dial("tcp", fmt.Sprintf("%s:%d", sc.Host, sc.SSHPort), config)


### PR DESCRIPTION
- fixed insecure-ignore-host-key-use

## Summary by Sourcery

Fix the insecure host key usage by implementing a custom HostKeyCallback function to validate hostnames, and enhance the Println function to ensure proper string formatting and output.

Bug Fixes:
- Replace the insecure host key callback with a custom HostKeyCallback function to ensure only allowed hostnames are used.

Enhancements:
- Improve the Println function to correctly format and print strings with a newline.