### PR TITLE
refactoring changes done

### DIFF
--- a/constants/main.go
+++ b/constants/main.go
@@ -25,7 +25,7 @@ func GetWireguardImageName() string {
 
 func GetK3SImageName() string {
 	//return "rancher/k3s:v1.27.5-k3s1"
-	return "ghcr.io/kloudlite/kl/k3s:latest"
+	return fmt.Sprintf("ghcr.io/kloudlite/kl/k3s:%s", flags.Version)
 }
 
 var (

--- a/domain/apiclient/clusters.go
+++ b/domain/apiclient/clusters.go
@@ -1,35 +1,36 @@
 package apiclient
 
-import (
-	fn "github.com/kloudlite/kl/pkg/functions"
-)
-
-type BYOKCluster struct {
-	DisplayName string   `json:"displayName"`
-	Metadata    Metadata `json:"metadata"`
-}
-
-func (apic *apiClient) ListBYOKClusters(teamName string) ([]BYOKCluster, error) {
-	cookie, err := getCookie(fn.MakeOption("teamName", teamName))
-	if err != nil {
-		return nil, fn.NewE(err)
-	}
-
-	respData, err := klFetch("cli_listAccountClusters", map[string]any{
-		"pq": map[string]any{
-			"orderBy":       "updateTime",
-			"sortDirection": "ASC",
-			"first":         99999999,
-		},
-	}, &cookie)
-
-	if err != nil {
-		return nil, fn.NewE(err)
-	}
-
-	if fromResp, err := GetFromRespForEdge[BYOKCluster](respData); err != nil {
-		return nil, fn.NewE(err)
-	} else {
-		return fromResp, fn.NewE(err)
-	}
-}
+//
+//import (
+//	fn "github.com/kloudlite/kl/pkg/functions"
+//)
+//
+//type BYOKCluster struct {
+//	DisplayName string   `json:"displayName"`
+//	Metadata    Metadata `json:"metadata"`
+//}
+//
+//func (apic *apiClient) ListBYOKClusters(teamName string) ([]BYOKCluster, error) {
+//	cookie, err := getCookie(fn.MakeOption("teamName", teamName))
+//	if err != nil {
+//		return nil, fn.NewE(err)
+//	}
+//
+//	respData, err := klFetch("cli_listAccountClusters", map[string]any{
+//		"pq": map[string]any{
+//			"orderBy":       "updateTime",
+//			"sortDirection": "ASC",
+//			"first":         99999999,
+//		},
+//	}, &cookie)
+//
+//	if err != nil {
+//		return nil, fn.NewE(err)
+//	}
+//
+//	if fromResp, err := GetFromRespForEdge[BYOKCluster](respData); err != nil {
+//		return nil, fn.NewE(err)
+//	} else {
+//		return fromResp, fn.NewE(err)
+//	}
+//}

--- a/domain/apiclient/impl.go
+++ b/domain/apiclient/impl.go
@@ -38,8 +38,8 @@ type ApiClient interface {
 	CheckEnvName(teamName, envName string) (bool, error)
 	GetLoadMaps() (map[string]string, MountMap, error)
 
-	ListBYOKClusters(teamName string) ([]BYOKCluster, error)
-
+	//ListBYOKClusters(teamName string) ([]BYOKCluster, error)
+	GetClustersOfTeam(team string) ([]Cluster, error)
 	ListMreses(teamName string, envName string) ([]Mres, error)
 	ListMresKeys(teamName, envName, importedManagedResource string) ([]string, error)
 	GetMresConfigValues(teamName string) (map[string]string, error)

--- a/domain/apiclient/k3s-local.go
+++ b/domain/apiclient/k3s-local.go
@@ -2,14 +2,17 @@ package apiclient
 
 import (
 	"os"
+	"time"
 
 	"github.com/kloudlite/kl/domain/fileclient"
 	fn "github.com/kloudlite/kl/pkg/functions"
 )
 
 type Cluster struct {
+	DisplayName    string          `json:"displayName"`
 	ClusterToken   string          `json:"clusterToken"`
 	Name           string          `json:"name"`
+	LastOnlineAt   time.Time       `json:"lastOnlineAt"`
 	InstallCommand *InstallCommand `json:"installCommand"`
 	Metadata       struct {
 		Name   string            `json:"name"`
@@ -34,7 +37,7 @@ type InstallCommand struct {
 	}
 }
 
-func (apic *apiClient) getClustersOfTeam(team string) ([]Cluster, error) {
+func (apic *apiClient) GetClustersOfTeam(team string) ([]Cluster, error) {
 	cookie, err := getCookie(fn.MakeOption("teamName", team))
 	if err != nil {
 		return nil, fn.NewE(err)
@@ -53,7 +56,7 @@ func (apic *apiClient) getClustersOfTeam(team string) ([]Cluster, error) {
 
 func (apic *apiClient) GetClusterConfig(team string) (*fileclient.TeamClusterConfig, error) {
 
-	existingClusters, err := apic.getClustersOfTeam(team)
+	existingClusters, err := apic.GetClustersOfTeam(team)
 	if err != nil {
 		return nil, err
 	}

--- a/k3s/impl.go
+++ b/k3s/impl.go
@@ -615,3 +615,23 @@ func (c *client) runScriptInContainer(script string) error {
 
 	return nil
 }
+
+func (c *client) CheckK3sRunningLocally() (bool, error) {
+	defer spinner.Client.UpdateMessage("checking k3s server")()
+	existingContainers, err := c.c.ContainerList(context.Background(), container.ListOptions{
+		All: true,
+		Filters: filters.NewArgs(
+			filters.Arg("label", fmt.Sprintf("%s=%s", CONT_MARK_KEY, "true")),
+			filters.Arg("label", fmt.Sprintf("%s=%s", "kl-k3s", "true")),
+		),
+	})
+	
+	if err != nil {
+		return false, fn.Errorf("failed to list containers: %w", err)
+	}
+
+	if len(existingContainers) == 0 {
+		return false, fn.Errorf("no k3s container running locally")
+	}
+	return true, nil
+}

--- a/k3s/k3s-base/Runfile.yml
+++ b/k3s/k3s-base/Runfile.yml
@@ -44,5 +44,11 @@ tasks:
 
   container:build:
     cmd:
-#      - run download:images
-      - docker buildx build --platform linux/amd64,linux/arm64 -t ghcr.io/kloudlite/kl/k3s:latest . --push
+      - docker buildx build --platform linux/amd64,linux/arm64 --build-arg VERSION=v1.0.0-nightly -t ghcr.io/kloudlite/kl/k3s:v1.0.0-nightly . --push
+
+  container:push:
+    preconditions:
+      - sh: '[[ -n "{{.tag}}" ]]'
+        msg: "var tag must have a value, of format 'v1.0.0-nightly'"
+    cmd:
+      - docker buildx build --platform linux/amd64,linux/arm64 --build-arg VERSION=${tag} -t ghcr.io/kloudlite/kl/k3s:${tag} . --push

--- a/k3s/main.go
+++ b/k3s/main.go
@@ -14,6 +14,7 @@ type K3sClient interface {
 	RestartWgProxyContainer() error
 	RemoveAllIntercepts() error
 	DeletePods() error
+	CheckK3sRunningLocally() (bool, error)
 }
 
 type client struct {


### PR DESCRIPTION
## Summary by Sourcery

Refactor cluster management functions to improve cluster selection and status logging. Enhance the WireGuard connection process by checking local K3s status before execution. Update Docker build tasks to support version tagging and pushing.

Enhancements:
- Refactor the `ListBYOKClusters` function to use `GetClustersOfTeam` for retrieving clusters, improving the cluster selection process.
- Enhance the `getK3sStatus` function to include more detailed logging of cluster and gateway status.
- Improve the `startWg` function to check if K3s is running locally before proceeding with WireGuard operations.
- Add a new method `CheckK3sRunningLocally` to the K3s client to verify the local running status of K3s containers.

Build:
- Update the Docker build process to include a version argument and add a new `container:push` task with preconditions for tagging.