### PR TITLE
stopall cmd added, status and connect command added

### DIFF
--- a/cmd/box/boxpkg/packagectrl/main.go
+++ b/cmd/box/boxpkg/packagectrl/main.go
@@ -3,6 +3,7 @@ package packagectrl
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/kloudlite/kl/pkg/ui/spinner"
 	"io"
 	"net/http"
 	"os"
@@ -25,6 +26,7 @@ func (p *Packages) Unmarshal(b []byte) error {
 }
 
 func SyncLockfileWithNewConfig(config fileclient.KLFileType) (map[string]string, error) {
+	defer spinner.Client.UpdateMessage("installing nix packages")()
 	_, err := os.Stat("kl.lock")
 	packages := Packages{}
 	if err == nil {

--- a/cmd/box/boxpkg/ssh.go
+++ b/cmd/box/boxpkg/ssh.go
@@ -60,7 +60,7 @@ func (c *client) Ssh() error {
 		return fn.NewE(err)
 	}
 
-	if err := c.waithForSshReady(port, cont.ID); err != nil {
+	if err := c.waitForSshReady(port, cont.ID); err != nil {
 		return fn.NewE(err)
 	}
 

--- a/cmd/box/klbox.go
+++ b/cmd/box/klbox.go
@@ -33,4 +33,7 @@ func init() {
 	fileclient.OnlyOutsideBox(infoCmd)
 	BoxCmd.AddCommand(infoCmd)
 
+	fileclient.OnlyOutsideBox(stopAllCmd)
+	BoxCmd.AddCommand(stopAllCmd)
+
 }

--- a/cmd/box/stop-all.go
+++ b/cmd/box/stop-all.go
@@ -1,0 +1,80 @@
+package box
+
+import (
+	"context"
+	"fmt"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
+	dockerclient "github.com/docker/docker/client"
+	"github.com/kloudlite/kl/cmd/box/boxpkg"
+	fn "github.com/kloudlite/kl/pkg/functions"
+	"github.com/kloudlite/kl/pkg/ui/spinner"
+	"github.com/kloudlite/kl/pkg/ui/text"
+	"github.com/spf13/cobra"
+	"strings"
+)
+
+var stopAllCmd = &cobra.Command{
+	Use:   "stop-all",
+	Short: "stop all running boxes",
+	Run: func(cmd *cobra.Command, args []string) {
+
+		fn.Logf(text.Yellow("[#] this action will stop all the running workspaces. this will end all current running processes in the container. do you want to do you want to proceed? [Y/n] "))
+		if !fn.Confirm(strings.ToUpper("Y"), strings.ToUpper("Y")) {
+			return
+		}
+
+		if err := stopAllContainers(); err != nil {
+			fn.PrintError(err)
+			return
+		}
+	},
+}
+
+func stopAllContainers() error {
+	defer spinner.Client.UpdateMessage("stopping running containers")()
+
+	c, err := dockerclient.NewClientWithOpts(dockerclient.FromEnv, dockerclient.WithAPIVersionNegotiation())
+	if err != nil {
+		return fn.NewE(err)
+	}
+	existingContainers, err := c.ContainerList(context.Background(), container.ListOptions{
+		All: true,
+		Filters: filters.NewArgs(
+			filters.Arg("label", fmt.Sprintf("%s=%s", boxpkg.CONT_MARK_KEY, "true")),
+		),
+	})
+	if err != nil {
+		return fn.NewE(err)
+	}
+
+	if len(existingContainers) == 0 {
+		return nil
+	}
+
+	for _, d := range existingContainers {
+
+		if d.Labels["kl-k3s"] == "true" {
+			continue
+		}
+
+		timeOut := 0
+		if err := c.ContainerStop(context.Background(), d.ID, container.StopOptions{
+			Timeout: &timeOut,
+		}); err != nil {
+			return fn.NewE(err)
+		}
+
+		if err := c.ContainerRemove(context.Background(), d.ID, container.RemoveOptions{
+			Force: true,
+		}); err != nil {
+			return fn.NewE(err)
+		}
+	}
+	spinner.Client.Stop()
+	return nil
+}
+
+func init() {
+	stopAllCmd.Aliases = append(stopAllCmd.Aliases, "stopall")
+}

--- a/cmd/cluster/down.go
+++ b/cmd/cluster/down.go
@@ -42,6 +42,10 @@ func StopK3sServer(cmd *cobra.Command) error {
 		return err
 	}
 
+	if len(crlist) == 0 {
+		return nil
+	}
+
 	k3sclient, err := k3s.NewClient()
 	if err != nil {
 		return err

--- a/cmd/connect/connect.go
+++ b/cmd/connect/connect.go
@@ -53,6 +53,7 @@ func startWg(cmd *cobra.Command) error {
 		if err := k3sClient.RestartWgProxyContainer(); err != nil {
 			return fn.NewE(err)
 		}
+		return nil
 	}
 
 	if err = fn.ExecNoOutput("wg-quick down kl-vpn 2> /dev/null | echo already down "); err != nil {

--- a/k3s/impl.go
+++ b/k3s/impl.go
@@ -594,7 +594,7 @@ func (c *client) runScriptInContainer(script string) error {
 			if len(line) > 8 {
 				line = line[8:]
 			}
-			fn.Log(text.Blue("[stdout]"), line)
+			fn.Log(text.Blue("[kube]"), line)
 		}
 
 	} else {

--- a/pkg/sshclient/ssh.go
+++ b/pkg/sshclient/ssh.go
@@ -2,6 +2,7 @@ package sshclient
 
 import (
 	"fmt"
+	"github.com/kloudlite/kl/pkg/ui/spinner"
 	"net"
 	"os"
 	"regexp"
@@ -102,6 +103,7 @@ func DoSSH(sc SSHConfig) error {
 var ErrSSHNotReady = fn.Error("ssh is not ready")
 
 func CheckSSHConnection(sc SSHConfig) error {
+	defer spinner.Client.UpdateMessage("checking ssh connection")()
 	pkFile, err := publicKeyFile(sc.KeyPath)
 	if err != nil {
 		return fn.Errorf("failed to parse private key: %s, please ensure you have the correct key", err)


### PR DESCRIPTION
## Summary by Sourcery

Add a new 'stop-all' command to stop all running containers and fix a typo in the SSH readiness function name. Enhance user feedback with updated spinner messages and improve error handling in the status command.

New Features:
- Introduce a new command 'stop-all' to stop all running containers, providing a user confirmation prompt before proceeding.

Bug Fixes:
- Fix a typo in the function name 'waithForSshReady' to 'waitForSshReady' across multiple files to ensure correct function calls.

Enhancements:
- Improve user feedback by updating spinner messages during various operations such as starting containers, checking SSH connections, and installing packages.
- Enhance error handling in the status command to provide more specific error messages when the kl file is not synced properly.