### PR TITLE
image tag version update

### DIFF
--- a/k3s/impl.go
+++ b/k3s/impl.go
@@ -272,7 +272,7 @@ func (c *client) generateConnectionScript(clusterConfig *fileclient.TeamClusterC
 		GatewayIP:      clusterConfig.GatewayIP,
 		ClusterCIDR:    clusterConfig.ClusterCIDR,
 		IpAddress:      vpnTeamConfig.IpAddress,
-		ImageTag:       flags.Version,
+		ImageTag:       clusterConfig.Version,
 	}
 
 	b := new(bytes.Buffer)


### PR DESCRIPTION
## Summary by Sourcery

Update the image tag version to be sourced from the cluster configuration instead of a static flag.

Enhancements:
- Update the image tag version source from a static flag to a dynamic cluster configuration.