### PR TITLE
device locally deleted on logout

### DIFF
--- a/domain/apiclient/k3s-local.go
+++ b/domain/apiclient/k3s-local.go
@@ -42,7 +42,9 @@ func (apic *apiClient) GetClustersOfTeam(team string) ([]Cluster, error) {
 	if err != nil {
 		return nil, fn.NewE(err)
 	}
-	fetch, err := klFetch("cli_listAccountClusters", map[string]any{}, &cookie)
+	fetch, err := klFetch("cli_listAccountClusters", map[string]any{
+		"pagination": PaginationDefault,
+	}, &cookie)
 	if err != nil {
 		return nil, fn.NewE(err)
 	}

--- a/domain/fileclient/auth.go
+++ b/domain/fileclient/auth.go
@@ -1,7 +1,6 @@
 package fileclient
 
 import (
-	"encoding/json"
 	fn "github.com/kloudlite/kl/pkg/functions"
 	"os"
 	"path"
@@ -45,42 +44,10 @@ func (fc *fclient) Logout() error {
 	vpnConfigPath := path.Join(configPath, "vpn")
 	_, err = os.Stat(vpnConfigPath)
 	if err == nil {
-		files, err := os.ReadDir(vpnConfigPath)
-
-		if err != nil {
+		if err := os.RemoveAll(vpnConfigPath); err != nil {
 			return fn.NewE(err)
 		}
-		for _, file := range files {
-			_, err := os.Stat(path.Join(vpnConfigPath, file.Name()))
-			if err != nil {
-				fn.PrintError(err)
-				continue
-			}
-			content, err := os.ReadFile(path.Join(vpnConfigPath, file.Name()))
-			if err != nil {
-				fn.PrintError(err)
-				continue
-			}
-
-			var data TeamVpnConfig
-			err = json.Unmarshal(content, &data)
-			if err != nil {
-				fn.PrintError(err)
-				continue
-			}
-			data.WGconf = ""
-
-			modifiedContent, err := json.Marshal(data)
-			if err != nil {
-				fn.PrintError(err)
-				continue
-			}
-
-			err = os.WriteFile(path.Join(vpnConfigPath, file.Name()), modifiedContent, 0644)
-			if err != nil {
-				fn.PrintError(err)
-			}
-		}
 	}
+
 	return os.Remove(path.Join(configPath, sessionFile.Name()))
 }

--- a/pkg/sshclient/ssh.go
+++ b/pkg/sshclient/ssh.go
@@ -2,7 +2,6 @@ package sshclient
 
 import (
 	"fmt"
-	"github.com/kloudlite/kl/pkg/ui/spinner"
 	"net"
 	"os"
 	"regexp"
@@ -103,7 +102,7 @@ func DoSSH(sc SSHConfig) error {
 var ErrSSHNotReady = fn.Error("ssh is not ready")
 
 func CheckSSHConnection(sc SSHConfig) error {
-	defer spinner.Client.UpdateMessage("checking ssh connection")()
+	//defer spinner.Client.UpdateMessage("checking ssh connection")()
 	pkFile, err := publicKeyFile(sc.KeyPath)
 	if err != nil {
 		return fn.Errorf("failed to parse private key: %s, please ensure you have the correct key", err)


### PR DESCRIPTION
## Summary by Sourcery

Enhance device creation by adding metadata labels for local UUID and ownership, and implement a method to list VPN devices with filtering. Simplify the logout process by removing the VPN configuration directory. Comment out the spinner update message in the SSH connection check function.

Bug Fixes:
- Remove unnecessary file reading and writing operations during logout by deleting the entire VPN configuration directory.

Enhancements:
- Add metadata labels to devices during creation to include local UUID and ownership information.
- Implement a method to list VPN devices for a team, filtering by local UUID and ownership.

Chores:
- Comment out the spinner update message in the SSH connection check function.