### PR TITLE
feat: adds docker socket proxy to host docker socket

### DIFF
--- a/cmd/box/boxpkg/utils.go
+++ b/cmd/box/boxpkg/utils.go
@@ -520,7 +520,7 @@ func (c *client) generateMounts() ([]mount.Mount, error) {
 	// }
 
 	volumes = append(volumes,
-		mount.Mount{Type: mount.TypeVolume, Source: dockerSock, Target: "/var/run/docker.sock"},
+		mount.Mount{Type: mount.TypeVolume, Source: dockerSock, Target: "/var/run/host-docker.sock"},
 	)
 
 	return volumes, nil

--- a/klbox-docker/Dockerfile
+++ b/klbox-docker/Dockerfile
@@ -16,9 +16,9 @@ ENV CGO_ENABLED=0
 RUN go build --tags=box -ldflags="-X github.com/kloudlite/kl/flags.Version=${VERSION} -X github.com/kloudlite/kl/flags.CliName=kl" -o ./bin/kl main.go
 
 
-FROM --platform=$TARGETPLATFORM ubuntu:latest
+FROM --platform=$TARGETPLATFORM ubuntu:24.04
 
-RUN apt-get update && apt-get install -y openssh-server sudo curl xz-utils jq iproute2 nano zsh git bzip2 wireguard-tools iputils-ping
+RUN apt-get update && apt-get install -y openssh-server sudo curl xz-utils jq iproute2 nano zsh git bzip2 wireguard-tools iputils-ping socat
 
 RUN mkdir /var/run/sshd
 
@@ -83,10 +83,11 @@ RUN chsh -s /bin/zsh kl
 
 COPY ./start.sh /start.sh
 COPY ./entrypoint.sh /entrypoint.sh
+COPY ./docker-socket.sh /docker-socket.sh
 
 RUN mkdir /kl-tmp && chown -R kl:kl /kl-tmp
 
-RUN chmod +x /start.sh /entrypoint.sh
+RUN chmod +x /start.sh /entrypoint.sh /docker-socket.sh
 
 COPY --from=builder /kl-app/bin/kl /usr/local/bin/kl
 

--- a/klbox-docker/Taskfile.yml
+++ b/klbox-docker/Taskfile.yml
@@ -34,8 +34,10 @@ tasks:
   #     - go run ./main.go exec
 
   container:build:
+    vars:
+      tag: '{{ .tag | default "v1.0.0-nightly" }}'
     cmds:
-      - eval docker buildx build "{{.buildx_args}}" --build-context project=.. --load -t {{.ImageBase}}/box:v1.0.0-nightly --build-arg VERSION=v1.0.0-nightly .
+      - eval docker buildx build "{{.buildx_args}}" --build-context project=.. --load -t {{.ImageBase}}/box:{{.tag}} --build-arg VERSION={{.tag}} .
 
   container:push:
     preconditions:

--- a/klbox-docker/docker-socket.sh
+++ b/klbox-docker/docker-socket.sh
@@ -1,0 +1,22 @@
+#! /usr/bin/env bash
+
+if [ $(id -u) -ne 0 ]; then
+	echo "This script must be run as root"
+	exit 1
+fi
+
+HOST_DOCKER_SOCKET=/var/run/host-docker.sock
+
+rm -f /var/run/docker.sock
+socat UNIX-LISTEN:/var/run/docker.sock,fork,reuseaddr UNIX-CONNECT:$HOST_DOCKER_SOCKET &
+pid=$!
+
+while true; do
+	if [ -x /var/run/docker.sock ]; then
+		chown kl /var/run/docker.sock
+		break
+	fi
+	sleep 1
+done
+
+wait $pid

--- a/klbox-docker/entrypoint.sh
+++ b/klbox-docker/entrypoint.sh
@@ -3,6 +3,8 @@
 set -o errexit
 set -o pipefail
 
+sudo /docker-socket.sh &
+
 /start.sh
 
 export SSH_PORT=$SSH_PORT


### PR DESCRIPTION
- it resolves permissions issues with changing ownership of host's docker socket (in case of immutable file systems, like fedora silverblue)

- also, pinned base ubuntu image to be a 24.04 one

## Summary by Sourcery

Add a Docker socket proxy to resolve permissions issues with the host's Docker socket and pin the base Ubuntu image to version 24.04.

New Features:
- Introduce a Docker socket proxy to handle permissions issues with the host's Docker socket, particularly for immutable file systems.

Enhancements:
- Pin the base Ubuntu image to version 24.04 in the Docker build process.