### PR TITLE
:art: Removed wait for cluster ready

### DIFF
--- a/k3s/impl.go
+++ b/k3s/impl.go
@@ -223,7 +223,8 @@ func (c *client) CreateClustersTeams(teamName string) error {
 			fn.Log(text.Yellow(fmt.Sprintf("Time taken to create cluster: %.2fs", time.Since(start).Seconds())))
 		}
 	}()
-	return c.EnsureK3sServerIsReady()
+	// return c.EnsureK3sServerIsReady()
+	return nil
 
 }
 


### PR DESCRIPTION
removed wait checks for cluster ready

## Summary by Sourcery

Remove the wait check for cluster readiness in the CreateClustersTeams function to streamline the cluster creation process.

Enhancements:
- Remove the wait check for cluster readiness in the CreateClustersTeams function.