### PR TITLE
kl file validation and api client unauthorization error handled

### DIFF
--- a/domain/apiclient/request.go
+++ b/domain/apiclient/request.go
@@ -116,6 +116,9 @@ func klFetch(method string, variables map[string]any, cookie *string, verbose ..
 	if len(respData.Errors) > 0 {
 		var errorMessages []string
 		for _, e := range respData.Errors {
+			if strings.Contains(e.Message, "no rolebinding found") {
+				return nil, fn.NewE(fn.Errorf("unauthorized"), fmt.Sprintf("error response from apiclient with method %s", method))
+			}
 			errorMessages = append(errorMessages, e.Message)
 		}
 

--- a/domain/fileclient/context.go
+++ b/domain/fileclient/context.go
@@ -402,7 +402,7 @@ func GetCookieString(options ...fn.Option) (string, error) {
 	}
 
 	if session == "" {
-		return "", fn.Errorf("no session found")
+		return "", fn.Errorf("unauthorized")
 	}
 
 	if accName != "" {

--- a/domain/fileclient/kl-file.go
+++ b/domain/fileclient/kl-file.go
@@ -52,7 +52,17 @@ func (c *fclient) WriteKLFile(fileObj KLFileType) error {
 }
 
 func (c *fclient) GetKlFile(filePath string) (*KLFileType, error) {
-	return c.getKlFile(filePath)
+	klfile, err := c.getKlFile(filePath)
+	if err != nil {
+		return nil, functions.NewE(err)
+	}
+	if klfile.TeamName == "" {
+		return nil, functions.Error("kl file is not valid, teamName is not set properly. You can re-initialize kl file by running \"kl init\" command.")
+	}
+	if klfile.DefaultEnv == "" {
+		return nil, functions.Error("kl file is not valid, defaultEnv is not set properly. You can re-intialize kl file by running \"kl init\" command.")
+	}
+	return klfile, nil
 }
 
 func (c *fclient) getKlFile(filePath string) (*KLFileType, error) {


### PR DESCRIPTION
## Summary by Sourcery

Improve KL file validation by checking for required fields and handle unauthorized errors in the API client by detecting specific error messages.

Bug Fixes:
- Handle unauthorized error in API client by checking for 'no rolebinding found' message and returning a specific error.

Enhancements:
- Add validation for KL files to ensure 'TeamName' and 'DefaultEnv' are set properly, providing specific error messages if they are not.