### PR TITLE
cluster up cmd and box ssh cmd updated

### DIFF
--- a/cmd/use/account.go
+++ b/cmd/use/account.go
@@ -20,7 +20,7 @@ var teamCmd = &cobra.Command{
 	},
 }
 
-func UseTeam(cmd *cobra.Command, options ...fn.Option) error {
+func UseTeam(cmd *cobra.Command) error {
 	apic, err := apiclient.New()
 	if err != nil {
 		return fn.NewE(err)

--- a/cmd/use/account.go
+++ b/cmd/use/account.go
@@ -22,15 +22,10 @@ var teamCmd = &cobra.Command{
 
 func UseTeam(cmd *cobra.Command, options ...fn.Option) error {
 	apic, err := apiclient.New()
-
-	fc, err := fileclient.New()
 	if err != nil {
 		return fn.NewE(err)
 	}
 
-	if err != nil {
-		return fn.NewE(err)
-	}
 	teams, err := apic.ListTeams()
 	if err != nil {
 		return fn.NewE(err)
@@ -56,12 +51,7 @@ func UseTeam(cmd *cobra.Command, options ...fn.Option) error {
 		return fn.NewE(err)
 	}
 
-	currentTeam, err := fc.CurrentTeamName()
-	if err != nil {
-		return fn.NewE(err)
-	}
-
-	if selectedTeam.Metadata.Name != currentTeam && currentTeam != "" {
+	if selectedTeam.Metadata.Name != data.SelectedTeam && data.SelectedTeam != "" {
 		if err := cluster.StopK3sServer(cmd); err != nil {
 			return fn.NewE(err)
 		}

--- a/cmd/use/account.go
+++ b/cmd/use/account.go
@@ -20,7 +20,7 @@ var teamCmd = &cobra.Command{
 	},
 }
 
-func UseTeam(cmd *cobra.Command) error {
+func UseTeam(cmd *cobra.Command, options ...fn.Option) error {
 	apic, err := apiclient.New()
 
 	fc, err := fileclient.New()
@@ -91,6 +91,6 @@ func UseTeam(cmd *cobra.Command) error {
 	//if err = k.CreateClustersTeams(selectedTeam.Metadata.Name); err != nil {
 	//	return fn.NewE(err)
 	//}
-	fn.Log("Selected team is ", selectedTeam.Metadata.Name)
+	fn.Log("Selected team is", selectedTeam.Metadata.Name)
 	return nil
 }

--- a/k3s/impl.go
+++ b/k3s/impl.go
@@ -208,7 +208,7 @@ func (c *client) CreateClustersTeams(teamName string) error {
 		return fn.NewE(err, "failed to start container")
 	}
 
-	script, err := c.generateConnectionScript(clusterConfig)
+	script, err := c.generateConnectionScript(clusterConfig, teamName)
 	if err != nil {
 		return fn.NewE(err, "failed to generate connection script")
 	}
@@ -228,7 +228,7 @@ func (c *client) CreateClustersTeams(teamName string) error {
 
 }
 
-func (c *client) generateConnectionScript(clusterConfig *fileclient.TeamClusterConfig) (string, error) {
+func (c *client) generateConnectionScript(clusterConfig *fileclient.TeamClusterConfig, teamName string) (string, error) {
 	defer spinner.Client.UpdateMessage("generating connection script")()
 	t := template.New("connectionScript")
 
@@ -240,11 +240,6 @@ func (c *client) generateConnectionScript(clusterConfig *fileclient.TeamClusterC
 	clusterConfig.Version = flags.Version
 	if clusterConfig.Version == "" || clusterConfig.Version == "v1.0.0-nightly" {
 		clusterConfig.Version = "v1.0.8-nightly"
-	}
-
-	teamName, err := c.fc.CurrentTeamName()
-	if err != nil {
-		return "", err
 	}
 
 	vpnTeamConfig, err := c.fc.GetVpnTeamConfig(teamName)


### PR DESCRIPTION
## Summary by Sourcery

Update the 'cluster up' and 'box ssh' commands to improve team context management and error handling. Introduce a confirmation step when switching teams and ensure the selected team is saved in the extra data file. Enhance error handling in the K3s server startup process.

Enhancements:
- Improve team context switching by prompting the user for confirmation and updating the selected team in the extra data file.
- Enhance error handling in the startK3sServer function by wrapping errors with functions.NewE for better error reporting.