### PR TITLE
team name should be taken from main team

### DIFF
--- a/cmd/status/status.go
+++ b/cmd/status/status.go
@@ -50,9 +50,9 @@ var Cmd = &cobra.Command{
 			return
 		}
 
-		acc, err := fc.CurrentTeamName()
+		data, err := fileclient.GetExtraData()
 		if err == nil {
-			fn.Log(fmt.Sprint(text.Bold(text.Blue("Team: ")), acc))
+			fn.Log(fmt.Sprint(text.Bold(text.Blue("Team: ")), data.SelectedTeam))
 		}
 
 		e, err := apic.EnsureEnv()
@@ -70,7 +70,7 @@ var Cmd = &cobra.Command{
 		fn.Log()
 		fn.Log(text.Bold("Cluster Status"))
 
-		config, err := fc.GetClusterConfig(acc)
+		config, err := fc.GetClusterConfig(data.SelectedTeam)
 		if err != nil {
 			if os.IsNotExist(err) {
 				fn.PrintError(fn.Error("kl file is not synced properly. please run \"kl init\" to re-initialized kl file"))


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix the retrieval of the team name by using the selected team from extra data instead of the current team name.