### PR TITLE
current env of team to be displayed

### DIFF
--- a/cmd/list/apps.go
+++ b/cmd/list/apps.go
@@ -42,8 +42,6 @@ func listapps(apic apiclient.ApiClient, fc fileclient.FileClient, cmd *cobra.Com
 		return functions.NewE(err)
 	}
 
-	envName := fn.ParseStringFlag(cmd, "env")
-
 	currentTeamName, err := fc.CurrentTeamName()
 	if err != nil {
 		return functions.NewE(err)
@@ -81,12 +79,11 @@ func listapps(apic apiclient.ApiClient, fc fileclient.FileClient, cmd *cobra.Com
 
 	fn.Println(table.Table(&header, rows, cmd))
 
-	table.KVOutput("apps of", envName, true)
+	table.KVOutput("apps of environment: ", currentEnvName.Name, true)
 	table.TotalResults(len(apps), true)
 	return nil
 }
 
 func init() {
 	appsCmd.Aliases = append(appsCmd.Aliases, "app")
-	appsCmd.Flags().StringP("env", "e", "", "environment name")
 }

--- a/cmd/list/configs.go
+++ b/cmd/list/configs.go
@@ -46,14 +46,14 @@ var configsCmd = &cobra.Command{
 			return
 		}
 
-		if err := printConfigs(apic, cmd, config); err != nil {
+		if err := printConfigs(apic, cmd, config, currentEnv.Name); err != nil {
 			fn.PrintError(err)
 			return
 		}
 	},
 }
 
-func printConfigs(apic apiclient.ApiClient, cmd *cobra.Command, configs []apiclient.Config) error {
+func printConfigs(apic apiclient.ApiClient, cmd *cobra.Command, configs []apiclient.Config, currentEnv string) error {
 	e, err := apic.EnsureEnv()
 	if err != nil {
 		return fn.NewE(err)
@@ -76,6 +76,8 @@ func printConfigs(apic apiclient.ApiClient, cmd *cobra.Command, configs []apicli
 	}
 
 	fn.Println(table.Table(&header, rows, cmd))
+
+	table.KVOutput("configs of environment: ", currentEnv, true)
 
 	table.TotalResults(len(configs), true)
 	return nil

--- a/cmd/list/mreses.go
+++ b/cmd/list/mreses.go
@@ -46,14 +46,14 @@ var mresCmd = &cobra.Command{
 			return
 		}
 
-		if err := printMres(apic, cmd, mres); err != nil {
+		if err := printMres(apic, cmd, mres, currentEnv.Name); err != nil {
 			fn.PrintError(err)
 			return
 		}
 	},
 }
 
-func printMres(apic apiclient.ApiClient, cmd *cobra.Command, mres []apiclient.Mres) error {
+func printMres(apic apiclient.ApiClient, cmd *cobra.Command, mres []apiclient.Mres, currentEnv string) error {
 	e, err := apic.EnsureEnv()
 	if err != nil {
 		return fn.NewE(err)
@@ -75,6 +75,7 @@ func printMres(apic apiclient.ApiClient, cmd *cobra.Command, mres []apiclient.Mr
 	}
 
 	fn.Println(table.Table(&header, rows))
+	table.KVOutput("managed resources of environment: ", currentEnv, true)
 	table.TotalResults(len(mres), true)
 	return nil
 }

--- a/cmd/list/secrets.go
+++ b/cmd/list/secrets.go
@@ -48,14 +48,14 @@ var secretsCmd = &cobra.Command{
 			return
 		}
 
-		if err := printSecrets(apic, cmd, sec); err != nil {
+		if err := printSecrets(apic, cmd, sec, currentEnv.Name); err != nil {
 			fn.PrintError(err)
 			return
 		}
 	},
 }
 
-func printSecrets(apic apiclient.ApiClient, cmd *cobra.Command, secrets []apiclient.Secret) error {
+func printSecrets(apic apiclient.ApiClient, cmd *cobra.Command, secrets []apiclient.Secret, currentEnv string) error {
 	e, err := apic.EnsureEnv()
 	if err != nil {
 		return fn.NewE(err)
@@ -78,6 +78,7 @@ func printSecrets(apic apiclient.ApiClient, cmd *cobra.Command, secrets []apicli
 	}
 
 	fn.Println(table.Table(&header, rows))
+	table.KVOutput("secrets of environment: ", currentEnv, true)
 	table.TotalResults(len(secrets), true)
 	return nil
 }


### PR DESCRIPTION
## Summary by Sourcery

Enhance the CLI to display the current environment name when listing configurations, applications, managed resources, and secrets, and remove the 'env' flag from the 'apps' command for a streamlined user experience.

New Features:
- Display the current environment name when listing configurations, applications, managed resources, and secrets.

Enhancements:
- Remove the 'env' flag from the 'apps' command, simplifying the command interface.