### PR TITLE
notify developers of new cli version and enable update via kl update command

### DIFF
--- a/clis/kl/root.go
+++ b/clis/kl/root.go
@@ -6,8 +6,9 @@ import (
 	"syscall"
 
 	"github.com/kloudlite/kl/flags"
-	"github.com/kloudlite/kl/pkg/functions"
+	fn "github.com/kloudlite/kl/pkg/functions"
 	"github.com/kloudlite/kl/pkg/ui/spinner"
+	"github.com/kloudlite/kl/pkg/updater"
 	"github.com/spf13/cobra"
 )
 
@@ -15,19 +16,35 @@ import (
 var rootCmd = &cobra.Command{
 	Use: flags.CliName,
 	PersistentPreRun: func(cmd *cobra.Command, _ []string) {
+
+		u := updater.NewUpdater()
+		b, err := u.CheckForUpdates()
+		if err != nil {
+			fn.PrintError(err)
+		}
+
+		if b {
+			s, err := u.GetUpdateMessage()
+			if err != nil {
+				fn.PrintError(err)
+			} else {
+				fn.Log(*s)
+			}
+		}
+
 		if s, ok := os.LookupEnv("KL_DEV"); ok && s == "true" {
 			flags.DevMode = "true"
 		} else if ok && s == "false" {
 			flags.DevMode = "false"
 		}
 
-		verbose := functions.ParseBoolFlag(cmd, "verbose")
+		verbose := fn.ParseBoolFlag(cmd, "verbose")
 		if verbose {
 			spinner.Client.SetVerbose(verbose)
 			flags.IsVerbose = verbose
 		}
 
-		quiet := functions.ParseBoolFlag(cmd, "quiet")
+		quiet := fn.ParseBoolFlag(cmd, "quiet")
 		if quiet {
 			spinner.Client.SetQuiet(quiet)
 			flags.IsQuiet = quiet

--- a/clis/kl/root.go
+++ b/clis/kl/root.go
@@ -80,7 +80,7 @@ func Execute() {
 func versionCheck() {
 	data, err := fileclient.GetExtraData()
 	if err == nil {
-		if time.Since(data.LastUpdateCheck).Seconds() > 2 {
+		if time.Since(data.LastUpdateCheck).Hours() > 12 {
 			u := updater.NewUpdater()
 			available, err := u.CheckForUpdates()
 			if err != nil {

--- a/clis/kl/root.go
+++ b/clis/kl/root.go
@@ -1,9 +1,12 @@
 package kl
 
 import (
+	"github.com/kloudlite/kl/domain/fileclient"
+	"github.com/kloudlite/kl/pkg/ui/text"
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/kloudlite/kl/flags"
 	"github.com/kloudlite/kl/pkg/functions"
@@ -56,9 +59,25 @@ func Execute() {
 	}
 }
 
+func versionCheck() {
+	data, err := fileclient.GetExtraData()
+	if err == nil {
+		if time.Since(data.LastUpdateCheck).Hours() > 24 {
+			// Todo(nxtCoder36): Add update version check with flags.Version
+			functions.Log(text.Yellow("It seems that kl is not updated recently. Please run \"kl update\" command."))
+			data.LastUpdateCheck = time.Now()
+			if err := fileclient.SaveExtraData(data); err != nil {
+				functions.Log(text.Yellow("Failed to save extra data"))
+			}
+		}
+	}
+}
+
 func init() {
 	rootCmd.Version = flags.Version
-
+	if !flags.IsDev() {
+		versionCheck()
+	}
 	for _, c := range rootCmd.Commands() {
 		c.PersistentFlags().BoolP("verbose", "v", false, "verbose output")
 		c.PersistentFlags().BoolP("quiet", "q", false, "quiet output")

--- a/clis/kl/update.go
+++ b/clis/kl/update.go
@@ -41,7 +41,7 @@ kl update
 func ExecUpdateCmd(version string) error {
 	uurl, err := updater.NewUpdater().GetUpdateUrl()
 	if err != nil {
-		return err
+		uurl = &constants.UpdateURL
 	}
 
 	if runtime.GOOS == constants.RuntimeWindows {

--- a/clis/kl/update.go
+++ b/clis/kl/update.go
@@ -24,13 +24,15 @@ Example:
 kl update
 `,
 	Run: func(cmd *cobra.Command, _ []string) {
-		version := fn.ParseStringFlag(cmd, "version")
+		//version := fn.ParseStringFlag(cmd, "version")
+		//
+		//if version != "" {
+		//	version = fmt.Sprintf("@%s", version)
+		//}
 
-		if version != "" {
-			version = fmt.Sprintf("@%s", version)
-		}
-
-		err := ExecUpdateCmd(version)
+		//err := ExecUpdateCmd(version)
+		// Todo(nxtCoder36): Add update version with flags.Version
+		err := ExecUpdateCmd("")
 		if err != nil {
 			fn.PrintError(err)
 			return
@@ -57,6 +59,7 @@ func ExecUpdateCmd(version string) error {
 	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	fmt.Println(cmd)
 
 	err := cmd.Run()
 	if err != nil {
@@ -72,5 +75,5 @@ func isCommandAvailable(command string) bool {
 }
 
 func init() {
-	UpdateCmd.Flags().StringP("version", "v", "", fmt.Sprintf("%s cli version", flags.CliName))
+	//UpdateCmd.Flags().StringP("version", "v", "", fmt.Sprintf("%s cli version", flags.CliName))
 }

--- a/cmd/status/status.go
+++ b/cmd/status/status.go
@@ -135,7 +135,7 @@ func getClusterK3sStatus(k3sTracker *fileclient.K3sTracker) error {
 	if k3sTracker.Compute && k3sTracker.Gateway {
 		fn.Log("Local Cluster: ", text.Green("ready"))
 	} else {
-		fn.Log("Local Cluster: ", text.Yellow("Not ready"))
+		fn.Log("Local Cluster: ", text.Yellow("not ready"))
 	}
 
 	if k3sTracker.WgConnection {

--- a/cmd/status/status.go
+++ b/cmd/status/status.go
@@ -135,7 +135,7 @@ func getClusterK3sStatus(k3sTracker *fileclient.K3sTracker) error {
 	if k3sTracker.Compute && k3sTracker.Gateway {
 		fn.Log("Local Cluster: ", text.Green("ready"))
 	} else {
-		fn.Log("Local Cluster: ", text.Yellow("not ready"))
+		fn.Log("Local Cluster: ", text.Yellow("Not ready"))
 	}
 
 	if k3sTracker.WgConnection {

--- a/constants/main.go
+++ b/constants/main.go
@@ -71,7 +71,7 @@ var (
 	}()
 
 	UpdateURL = func() string {
-		return "https://kl.kloudlite.io/kloudlite"
+		return "https://kl.kloudlite.io/kloudlite/kloudlite"
 	}()
 )
 

--- a/constants/main.go
+++ b/constants/main.go
@@ -69,6 +69,10 @@ var (
 	ServerURL = func() string {
 		return fmt.Sprintf("%s/api/", BaseURL)
 	}()
+
+	UpdateURL = func() string {
+		return "https://kl.kloudlite.io/kloudlite/kloudlite"
+	}()
 )
 
 var (

--- a/constants/main.go
+++ b/constants/main.go
@@ -70,9 +70,9 @@ var (
 		return fmt.Sprintf("%s/api/", BaseURL)
 	}()
 
-	UpdateURL = func() string {
-		return "https://kl.kloudlite.io/kloudlite"
-	}()
+	// UpdateURL = func() string {
+	// 	return "https://kl.kloudlite.io/kloudlite/kloudlite"
+	// }()
 )
 
 var (

--- a/domain/fileclient/context.go
+++ b/domain/fileclient/context.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"runtime"
 	"strings"
+	"time"
 
 	uuid "github.com/nu7hatch/gouuid"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
@@ -80,10 +81,11 @@ type InfraContexts struct {
 }
 
 type ExtraData struct {
-	BaseUrl       string          `json:"baseUrl"`
-	SelectedTeam  string          `json:"selectedTeam"`
-	DnsHostSuffix string          `json:"dnsHostSuffix"`
-	SelectedEnvs  map[string]*Env `json:"selectedEnvs"`
+	BaseUrl         string          `json:"baseUrl"`
+	SelectedTeam    string          `json:"selectedTeam"`
+	DnsHostSuffix   string          `json:"dnsHostSuffix"`
+	SelectedEnvs    map[string]*Env `json:"selectedEnvs"`
+	LastUpdateCheck time.Time       `json:"lastUpdateCheck"`
 }
 
 type Port struct {

--- a/pkg/updater/main.go
+++ b/pkg/updater/main.go
@@ -1,0 +1,164 @@
+package updater
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+
+	"github.com/kloudlite/kl/flags"
+	fn "github.com/kloudlite/kl/pkg/functions"
+	"github.com/kloudlite/kl/pkg/ui/text"
+)
+
+type updater struct {
+	releaseInfo map[string]string
+}
+
+type Updater interface {
+	CheckForUpdates() (bool, error)
+	GetUpdateMessage() (*string, error)
+	Update() error
+	GetUpdateUrl() (*string, error)
+}
+
+func NewUpdater() Updater {
+	return &updater{}
+}
+
+func (u *updater) GetUpdateUrl() (*string, error) {
+	relInfo, err := u.fetchReleaseInfo()
+	if err != nil {
+		return nil, err
+	}
+
+	updateUrl, ok := relInfo["update_url"]
+	if !ok {
+		return nil, fn.Errorf("update url is not available")
+	}
+
+	b, err := base64.StdEncoding.DecodeString(updateUrl)
+	if err != nil {
+		return nil, fn.NewE(err, "failed to decode update url")
+	}
+
+	updateUrl = string(b)
+
+	return &updateUrl, nil
+}
+
+func (u *updater) Update() error {
+	relInfo, err := u.fetchReleaseInfo()
+	if err != nil {
+		fn.PrintError(err)
+		return err
+	}
+
+	updateUrl, ok := relInfo["update_url"]
+	if !ok {
+		return fn.Errorf("update url is not available")
+	}
+
+	r, err := http.Get(updateUrl)
+	if err != nil {
+		return err
+	}
+
+	fn.Log(r)
+	return nil
+}
+
+func parseTxtResp(data string) (map[string]string, error) {
+	res := make(map[string]string)
+	pairs := strings.Split(data, ";")
+
+	for _, pair := range pairs {
+		if pair == "" {
+			continue
+		}
+		kv := strings.Split(pair, ":")
+		if len(kv) != 2 {
+			fn.Debug(fmt.Sprintf("Invalid record %s", pair))
+			continue
+		}
+
+		res[kv[0]] = kv[1]
+	}
+
+	return res, nil
+}
+
+func (u *updater) fetchReleaseInfo() (map[string]string, error) {
+
+	if u.releaseInfo != nil {
+		return u.releaseInfo, nil
+	}
+
+	// use rest api for it
+	s, err := net.LookupTXT("klversion.kloudlite.io")
+	if err != nil {
+		return nil, fn.NewE(err, "Failed to fetch txt records")
+	}
+
+	if len(s) == 0 {
+		return nil, fn.Errorf("No records found for url klversion.kloudlite.io")
+	}
+
+	m, err := parseTxtResp(s[0])
+	if err != nil {
+		return nil, fn.NewE(err)
+	}
+
+	u.releaseInfo = m
+	return m, nil
+}
+
+func (u *updater) CheckForUpdates() (bool, error) {
+	// fetch dns records of txt records of url facebook.com
+
+	relInfo, err := u.fetchReleaseInfo()
+	if err != nil {
+		return false, err
+	}
+
+	vcode, ok := relInfo["version"]
+	if !ok {
+		return false, fn.Errorf("Failed to fetch release info")
+	}
+
+	if vcode != flags.Version {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func (u *updater) GetUpdateMessage() (*string, error) {
+
+	relInfo, err := u.fetchReleaseInfo()
+	if err != nil {
+		fn.PrintError(err)
+		return nil, err
+	}
+
+	latestVersion, ok := relInfo["version"]
+	if !ok {
+		fn.PrintError(fn.Errorf("Failed to fetch release info"))
+		return nil, err
+	}
+
+	currentVersion := flags.Version
+
+	resp := ""
+	resp += text.Red(fmt.Sprintf("\nA new version of %s is available (%s -> %s)", flags.CliName, currentVersion, latestVersion))
+
+	resp += "\n"
+	resp += "\n"
+	resp += "To update, run the following command:"
+	resp += "\n"
+	resp += text.Green(fmt.Sprintf("  %s", text.Bold("kl update")))
+	resp += "\n"
+
+	return &resp, nil
+}


### PR DESCRIPTION
- added latest release check and fixed update command

## Summary by Sourcery

Add a feature to notify developers of new CLI versions and enable updates via the 'kl update' command. Implement a version check mechanism to alert users when a new version is available and provide instructions for updating.

New Features:
- Introduce a new CLI command 'kl update' to update the CLI to the latest version.

Enhancements:
- Implement a version check mechanism that notifies developers of a new CLI version if available.