### PR TITLE
Impl/cmd expose port

### DIFF
--- a/clis/kl/loadsubs.go
+++ b/clis/kl/loadsubs.go
@@ -6,6 +6,7 @@ import (
 	"github.com/kloudlite/kl/cmd/clone"
 	"github.com/kloudlite/kl/cmd/cluster"
 	"github.com/kloudlite/kl/cmd/connect"
+	"github.com/kloudlite/kl/cmd/expose"
 	"github.com/kloudlite/kl/cmd/get"
 	"github.com/kloudlite/kl/cmd/intercept"
 	"github.com/kloudlite/kl/cmd/list"
@@ -44,6 +45,7 @@ func init() {
 	//rootCmd.AddCommand(vpn.Cmd)
 
 	rootCmd.AddCommand(cluster.Cmd)
+	rootCmd.AddCommand(expose.Cmd)
 
 	rootCmd.AddCommand(add.Command)
 	rootCmd.AddCommand(status.Cmd)

--- a/clis/kl/update.go
+++ b/clis/kl/update.go
@@ -60,7 +60,6 @@ func ExecUpdateCmd(version string) error {
 	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	fmt.Println(cmd)
 
 	if err = cmd.Run(); err != nil {
 		return functions.NewE(err)

--- a/cmd/box/boxpkg/main.go
+++ b/cmd/box/boxpkg/main.go
@@ -37,7 +37,7 @@ type client struct {
 }
 
 type BoxClient interface {
-	//SyncProxy(config ProxyConfig) error
+	SyncProxy(config ProxyConfig) error
 	Stop() error
 	Restart() error
 	Start() error

--- a/cmd/box/boxpkg/proxy.go
+++ b/cmd/box/boxpkg/proxy.go
@@ -3,6 +3,13 @@ package boxpkg
 import (
 	"crypto/md5"
 	"fmt"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/api/types/network"
+	"github.com/docker/go-connections/nat"
+	"github.com/kloudlite/kl/constants"
+	"github.com/kloudlite/kl/pkg/functions"
+	"github.com/kloudlite/kl/pkg/ui/spinner"
 
 	"github.com/kloudlite/kl/pkg/egob"
 )
@@ -25,114 +32,114 @@ func (c *ProxyConfig) GetHash() string {
 	return fmt.Sprintf("%x", hash.Sum(nil))
 }
 
-//func (c *client) SyncProxy(config ProxyConfig) error {
-//	defer spinner.Client.UpdateMessage("updating port configuration")()
-//
-//	if err := c.ensureImage(constants.SocatImage); err != nil {
-//		return functions.NewE(err, "failed to pull image")
-//	}
-//
-//	existingProxies, err := c.cli.ContainerList(context.Background(), container.ListOptions{
-//		Filters: filters.NewArgs(
-//			dockerLabelFilter(CONT_MARK_KEY, "true"),
-//			dockerLabelFilter("proxy", "true"),
-//		),
-//	})
-//	if err != nil {
-//		return functions.NewE(err, "failed to list containers")
-//	}
-//
-//	if len(existingProxies) > 0 {
-//		portHash := existingProxies[0].Labels["port-hash"]
-//		if portHash == config.GetHash() && existingProxies[0].State == "running" {
-//			return nil
-//		}
-//	}
-//
-//	targetContainers, err := c.cli.ContainerList(context.Background(), container.ListOptions{
-//		Filters: filters.NewArgs(
-//			dockerLabelFilter(CONT_MARK_KEY, "true"),
-//			dockerLabelFilter(CONT_PATH_KEY, config.TargetContainerPath),
-//		),
-//	})
-//	if err != nil {
-//		return functions.NewE(err, "failed to list containers")
-//	}
-//
-//	if len(targetContainers) == 0 {
-//		return nil
-//	}
-//
-//	if len(existingProxies) > 0 {
-//		if err := c.cli.ContainerKill(context.Background(), existingProxies[0].ID, "SIGKILL"); err != nil {
-//			return functions.NewE(err, "failed to stop container")
-//		}
-//
-//		if err = c.cli.ContainerRemove(context.Background(), existingProxies[0].ID, container.RemoveOptions{
-//			Force: true,
-//		}); err != nil {
-//			return functions.NewE(err, "failed to remove container")
-//		}
-//	}
-//
-//	if len(config.ExposedPorts) == 0 {
-//		return nil
-//	}
-//
-//	targetContainer := targetContainers[0]
-//	targetIpAddress := targetContainer.NetworkSettings.Networks["kloudlite"].IPAddress
-//	socatCommand := ""
-//	for _, port := range config.ExposedPorts {
-//		socatCommand += fmt.Sprintf(`socat TCP-LISTEN:%d,fork TCP:%s:%d & `, port, targetIpAddress, port)
-//		socatCommand += fmt.Sprintf(`socat UDP-RECVFROM:%d,fork UDP-SENDTO:%s:%d & `, port, targetIpAddress, port)
-//	}
-//	socatCommand += "tail -f /dev/null"
-//
-//	resp, err := c.cli.ContainerCreate(context.Background(), &container.Config{
-//		Image: constants.SocatImage,
-//		Labels: map[string]string{
-//			CONT_MARK_KEY: "true",
-//			"proxy":       "true",
-//			"port-hash":   config.GetHash(),
-//		},
-//		ExposedPorts: func() nat.PortSet {
-//			ports := nat.PortSet{}
-//			for _, port := range config.ExposedPorts {
-//				ports[nat.Port(fmt.Sprintf("%d/tcp", port))] = struct{}{}
-//				ports[nat.Port(fmt.Sprintf("%d/udp", port))] = struct{}{}
-//			}
-//			return ports
-//		}(),
-//		Entrypoint: []string{"sh", "-c", socatCommand},
-//	}, &container.HostConfig{
-//		PortBindings: func() nat.PortMap {
-//			portBindings := nat.PortMap{}
-//			for _, port := range config.ExposedPorts {
-//				portBindings[nat.Port(fmt.Sprintf("%d/tcp", port))] = []nat.PortBinding{
-//					{
-//						HostPort: fmt.Sprintf("%d", port),
-//					},
-//				}
-//				portBindings[nat.Port(fmt.Sprintf("%d/udp", port))] = []nat.PortBinding{
-//					{
-//						HostPort: fmt.Sprintf("%d", port),
-//					},
-//				}
-//			}
-//			return portBindings
-//		}(),
-//	}, &network.NetworkingConfig{
-//		EndpointsConfig: map[string]*network.EndpointSettings{
-//			"kloudlite": {},
-//		},
-//	}, nil, "")
-//
-//	if err != nil {
-//		return functions.NewE(err, "failed to create container")
-//	}
-//
-//	if err := c.cli.ContainerStart(context.Background(), resp.ID, container.StartOptions{}); err != nil {
-//		return functions.NewE(err, "failed to start container")
-//	}
-//	return nil
-//}
+func (c *client) SyncProxy(config ProxyConfig) error {
+	defer spinner.Client.UpdateMessage("updating port configuration")()
+
+	if err := c.ensureImage(constants.SocatImage); err != nil {
+		return functions.NewE(err, "failed to pull image")
+	}
+
+	existingProxies, err := c.cli.ContainerList(c.cmd.Context(), container.ListOptions{
+		Filters: filters.NewArgs(
+			dockerLabelFilter(CONT_MARK_KEY, "true"),
+			dockerLabelFilter("proxy", "true"),
+		),
+	})
+	if err != nil {
+		return functions.NewE(err, "failed to list containers")
+	}
+
+	if len(existingProxies) > 0 {
+		portHash := existingProxies[0].Labels["port-hash"]
+		if portHash == config.GetHash() && existingProxies[0].State == "running" {
+			return nil
+		}
+	}
+
+	targetContainers, err := c.cli.ContainerList(c.cmd.Context(), container.ListOptions{
+		Filters: filters.NewArgs(
+			dockerLabelFilter(CONT_MARK_KEY, "true"),
+			dockerLabelFilter(CONT_PATH_KEY, config.TargetContainerPath),
+		),
+	})
+	if err != nil {
+		return functions.NewE(err, "failed to list containers")
+	}
+
+	if len(targetContainers) == 0 {
+		return nil
+	}
+
+	if len(existingProxies) > 0 {
+		if err := c.cli.ContainerKill(c.cmd.Context(), existingProxies[0].ID, "SIGKILL"); err != nil {
+			return functions.NewE(err, "failed to stop container")
+		}
+
+		if err = c.cli.ContainerRemove(c.cmd.Context(), existingProxies[0].ID, container.RemoveOptions{
+			Force: true,
+		}); err != nil {
+			return functions.NewE(err, "failed to remove container")
+		}
+	}
+
+	if len(config.ExposedPorts) == 0 {
+		return nil
+	}
+
+	targetContainer := targetContainers[0]
+	targetIpAddress := targetContainer.NetworkSettings.Networks["kloudlite"].IPAddress
+	socatCommand := ""
+	for _, port := range config.ExposedPorts {
+		socatCommand += fmt.Sprintf(`socat TCP-LISTEN:%d,fork TCP:%s:%d & `, port, targetIpAddress, port)
+		socatCommand += fmt.Sprintf(`socat UDP-RECVFROM:%d,fork UDP-SENDTO:%s:%d & `, port, targetIpAddress, port)
+	}
+	socatCommand += "tail -f /dev/null"
+
+	resp, err := c.cli.ContainerCreate(c.cmd.Context(), &container.Config{
+		Image: constants.SocatImage,
+		Labels: map[string]string{
+			CONT_MARK_KEY: "true",
+			"proxy":       "true",
+			"port-hash":   config.GetHash(),
+		},
+		ExposedPorts: func() nat.PortSet {
+			ports := nat.PortSet{}
+			for _, port := range config.ExposedPorts {
+				ports[nat.Port(fmt.Sprintf("%d/tcp", port))] = struct{}{}
+				ports[nat.Port(fmt.Sprintf("%d/udp", port))] = struct{}{}
+			}
+			return ports
+		}(),
+		Entrypoint: []string{"sh", "-c", socatCommand},
+	}, &container.HostConfig{
+		PortBindings: func() nat.PortMap {
+			portBindings := nat.PortMap{}
+			for _, port := range config.ExposedPorts {
+				portBindings[nat.Port(fmt.Sprintf("%d/tcp", port))] = []nat.PortBinding{
+					{
+						HostPort: fmt.Sprintf("%d", port),
+					},
+				}
+				portBindings[nat.Port(fmt.Sprintf("%d/udp", port))] = []nat.PortBinding{
+					{
+						HostPort: fmt.Sprintf("%d", port),
+					},
+				}
+			}
+			return portBindings
+		}(),
+	}, &network.NetworkingConfig{
+		EndpointsConfig: map[string]*network.EndpointSettings{
+			"kloudlite": {},
+		},
+	}, nil, "")
+
+	if err != nil {
+		return functions.NewE(err, "failed to create container")
+	}
+
+	if err := c.cli.ContainerStart(c.cmd.Context(), resp.ID, container.StartOptions{}); err != nil {
+		return functions.NewE(err, "failed to start container")
+	}
+	return nil
+}

--- a/cmd/expose/expose.go
+++ b/cmd/expose/expose.go
@@ -1,0 +1,15 @@
+package expose
+
+import "github.com/spf13/cobra"
+
+var Cmd = &cobra.Command{
+	Use:   "expose",
+	Short: "expose ports",
+	Long:  "This command will add ports to your kl-config file",
+}
+
+func init() {
+	Cmd.AddCommand(portsCmd)
+	Cmd.AddCommand(syncCmd)
+	portsCmd.Aliases = []string{"ports"}
+}

--- a/cmd/expose/port.go
+++ b/cmd/expose/port.go
@@ -1,0 +1,85 @@
+package expose
+
+import (
+	"os"
+	"slices"
+	"strconv"
+
+	"github.com/kloudlite/kl/cmd/box/boxpkg"
+	"github.com/kloudlite/kl/domain/fileclient"
+	"github.com/kloudlite/kl/pkg/functions"
+	fn "github.com/kloudlite/kl/pkg/functions"
+	"github.com/kloudlite/kl/pkg/ui/text"
+	"github.com/spf13/cobra"
+)
+
+var portsCmd = &cobra.Command{
+	Use:   "port",
+	Short: "expose ports",
+	Long: `
+This command will add ports to your kl-config file.
+`,
+	Example: ` 
+  kl expose ports 8080 3000
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := exposePorts(cmd, args); err != nil {
+			fn.PrintError(err)
+			return
+		}
+	},
+}
+
+func exposePorts(cmd *cobra.Command, args []string) error {
+	fc, err := fileclient.New()
+	if err != nil {
+		return functions.NewE(err)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return functions.NewE(err)
+	}
+
+	klFile, err := fc.GetKlFile("")
+	if err != nil {
+		return functions.NewE(err)
+	}
+
+	if len(args) == 0 {
+		return functions.Errorf("no ports provided. please provide ports using %s", text.Yellow("kl expose port 8080 3000"))
+	}
+
+	for _, arg := range args {
+		port, err := strconv.Atoi(arg)
+		if err != nil {
+			return functions.NewE(err, "port should be an integer")
+		}
+		if !slices.Contains(klFile.Ports, port) {
+			klFile.Ports = append(klFile.Ports, port)
+		}
+	}
+
+	if err := fc.WriteKLFile(*klFile); err != nil {
+		return functions.NewE(err)
+	}
+
+	containerWorkspacePath := cwd
+	if val, ok := os.LookupEnv("KL_WORKSPACE"); ok {
+		containerWorkspacePath = val
+	}
+
+	c, err := boxpkg.NewClient(cmd, args)
+	if err != nil {
+		return functions.NewE(err)
+	}
+
+	if err = c.SyncProxy(boxpkg.ProxyConfig{
+		ExposedPorts:        klFile.Ports,
+		TargetContainerPath: containerWorkspacePath,
+	}); err != nil {
+		return fn.NewE(err)
+	}
+
+	return nil
+}

--- a/cmd/expose/sync.go
+++ b/cmd/expose/sync.go
@@ -1,0 +1,61 @@
+package expose
+
+import (
+	"os"
+
+	"github.com/kloudlite/kl/cmd/box/boxpkg"
+	"github.com/kloudlite/kl/domain/fileclient"
+	"github.com/kloudlite/kl/pkg/functions"
+	fn "github.com/kloudlite/kl/pkg/functions"
+	"github.com/spf13/cobra"
+)
+
+var syncCmd = &cobra.Command{
+	Use:   "sync",
+	Short: "sync ports",
+	Long: `
+This command will sync ports to your kl-config file.
+`,
+	Example: ` 
+  kl expose sync
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := sync(cmd, args); err != nil {
+			fn.PrintError(err)
+			return
+		}
+	},
+}
+
+func sync(cmd *cobra.Command, args []string) error {
+	fc, err := fileclient.New()
+	if err != nil {
+		return functions.NewE(err)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return functions.NewE(err)
+	}
+	klFile, err := fc.GetKlFile("")
+	if err != nil {
+		return functions.NewE(err)
+	}
+	containerWorkspacePath := cwd
+	if val, ok := os.LookupEnv("KL_WORKSPACE"); ok {
+		containerWorkspacePath = val
+	}
+
+	c, err := boxpkg.NewClient(cmd, args)
+	if err != nil {
+		return functions.NewE(err)
+	}
+
+	if err = c.SyncProxy(boxpkg.ProxyConfig{
+		ExposedPorts:        klFile.Ports,
+		TargetContainerPath: containerWorkspacePath,
+	}); err != nil {
+		return fn.NewE(err)
+	}
+	return nil
+}

--- a/cmd/status/status.go
+++ b/cmd/status/status.go
@@ -135,7 +135,7 @@ func getClusterK3sStatus(k3sTracker *fileclient.K3sTracker) error {
 	if k3sTracker.Compute && k3sTracker.Gateway {
 		fn.Log("Local Cluster: ", text.Green("ready"))
 	} else {
-		fn.Log("Local Cluster: ", text.Yellow("Not ready"))
+		fn.Log("Local Cluster: ", text.Yellow("not ready"))
 	}
 
 	if k3sTracker.WgConnection {

--- a/constants/main.go
+++ b/constants/main.go
@@ -13,6 +13,7 @@ const (
 	RuntimeLinux   = "linux"
 	RuntimeDarwin  = "darwin"
 	RuntimeWindows = "windows"
+	SocatImage     = "ghcr.io/kloudlite/hub/socat:latest"
 
 	KLDNS                       = "100.64.0.1"
 	InterceptWorkspaceServiceIp = "172.18.0.3"

--- a/domain/fileclient/kl-file.go
+++ b/domain/fileclient/kl-file.go
@@ -16,6 +16,7 @@ type KLFileType struct {
 
 	EnvVars EnvVars `json:"envVars" yaml:"envVars"`
 	Mounts  Mounts  `json:"mounts" yaml:"mounts"`
+	Ports   []int   `json:"ports" yaml:"ports"`
 
 	// InitScripts []string `json:"initScripts" yaml:"initScripts"`
 	TeamName string `json:"teamName" yaml:"teamName"`

--- a/pkg/updater/main.go
+++ b/pkg/updater/main.go
@@ -127,8 +127,6 @@ func (u *updater) CheckForUpdates() (bool, error) {
 		return false, fn.Errorf("Failed to fetch release info")
 	}
 
-	fmt.Println(vcode, flags.Version)
-
 	if vcode != flags.Version {
 		return true, nil
 	}


### PR DESCRIPTION
## Summary by Sourcery

Add a new 'expose' command to manage port exposure in the kl-config file, including functionality to add and sync ports. Refactor the SyncProxy function to utilize the command context for Docker operations, enhancing code clarity. Clean up code by removing redundant print statements.

New Features:
- Introduce a new 'expose' command to manage port exposure in the kl-config file, including subcommands for adding and syncing ports.

Enhancements:
- Refactor the SyncProxy function to use the command context for Docker operations, improving code clarity and maintainability.

Chores:
- Remove unnecessary print statements from the updater and update command files.