### PR TITLE
docker image should run with current user id and group id

### DIFF
--- a/cmd/box/boxpkg/info.go
+++ b/cmd/box/boxpkg/info.go
@@ -43,6 +43,6 @@ func (c *client) Info() error {
 
 	fn.Logf("%s %s %s\n", text.Bold("command:"), text.Blue("ssh"), text.Blue(strings.Join([]string{fmt.Sprintf("kl@%s", getDomainFromPath(c.cwd)), "-p", fmt.Sprint(sshPort), "-oStrictHostKeyChecking=no"}, " ")))
 
-	fn.Logf("%s %s\n", text.Bold("vscode:"), text.Blue(fmt.Sprintf("vscode://vscode-remote/ssh-remote+kl@%s:%s/workspace", getDomainFromPath(c.cwd), sshPort)))
+	fn.Logf("%s %s\n", text.Bold("vscode:"), text.Blue(fmt.Sprintf("vscode://vscode-remote/ssh-remote+kl@%s:%s/home/kl/workspace", getDomainFromPath(c.cwd), sshPort)))
 	return nil
 }

--- a/cmd/box/boxpkg/start.go
+++ b/cmd/box/boxpkg/start.go
@@ -136,7 +136,7 @@ func (c *client) Start() error {
 	}
 
 	fn.Logf("%s %s %s\n", text.Bold("command:"), text.Blue("ssh"), text.Blue(strings.Join([]string{fmt.Sprintf("kl@%s", getDomainFromPath(c.cwd)), "-p", fmt.Sprint(c.env.SSHPort), "-oStrictHostKeyChecking=no"}, " ")))
-	fn.Logf("%s %s\n", text.Bold("vscode:"), text.Blue(fmt.Sprintf("vscode://vscode-remote/ssh-remote+kl@%s:%s/workspace", getDomainFromPath(c.cwd), fmt.Sprint(c.env.SSHPort))))
+	fn.Logf("%s %s\n", text.Bold("vscode:"), text.Blue(fmt.Sprintf("vscode://vscode-remote/ssh-remote+kl@%s:%s/home/kl/workspace", getDomainFromPath(c.cwd), fmt.Sprint(c.env.SSHPort))))
 
 	return nil
 }

--- a/cmd/box/boxpkg/utils.go
+++ b/cmd/box/boxpkg/utils.go
@@ -438,7 +438,8 @@ func (c *client) generateMounts() ([]mount.Mount, error) {
 	}
 
 	sshPath := path.Join(userHomeDir, ".ssh", "id_rsa.pub")
-	rsaPath := path.Join(userHomeDir, ".ssh", "id_rsa")
+	//rsaPath := path.Join(userHomeDir, ".ssh", "id_rsa")
+	sshDir := path.Join(userHomeDir, ".ssh")
 
 	akByte, err := os.ReadFile(sshPath)
 	if err != nil {
@@ -502,10 +503,11 @@ func (c *client) generateMounts() ([]mount.Mount, error) {
 	}
 
 	volumes := []mount.Mount{
-		{Type: mount.TypeBind, Source: akTmpPath, Target: "/tmp/ssh2/authorized_keys", ReadOnly: true},
-		{Type: mount.TypeBind, Source: sshPath, Target: "/tmp/ssh2/id_rsa.pub", ReadOnly: true},
-		{Type: mount.TypeBind, Source: rsaPath, Target: "/tmp/ssh2/id_rsa", ReadOnly: true},
 		{Type: mount.TypeVolume, Source: "kl-home-cache", Target: "/home"},
+		//{Type: mount.TypeBind, Source: rsaPath, Target: "/tmp/ssh2/id_rsa", ReadOnly: true},
+		//  NOTE: never change the order of ssh mount
+		{Type: mount.TypeBind, Source: sshDir, Target: "/home/kl/.ssh", ReadOnly: true},
+		{Type: mount.TypeBind, Source: akTmpPath, Target: "/home/kl/.ssh/authorized_keys", ReadOnly: true},
 		//{Type: mount.TypeBind, Source: gitConfigPath, Target: "/tmp/gitconfig/.gitconfig", ReadOnly: true},
 		{Type: mount.TypeVolume, Source: "kl-nix-store", Target: "/nix"},
 		{Type: mount.TypeBind, Source: configFolder, Target: "/.cache/kl"},

--- a/cmd/box/boxpkg/utils.go
+++ b/cmd/box/boxpkg/utils.go
@@ -250,6 +250,7 @@ func (c *client) startContainer(klconfHash string) (string, error) {
 	clusterConfig, err := c.fc.GetClusterConfig(currentSystemConfig.SelectedTeam)
 
 	resp, err := c.cli.ContainerCreate(context.Background(), &container.Config{
+		User:  fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()),
 		Image: constants.GetBoxImageName(),
 		Labels: map[string]string{
 			CONT_MARK_KEY:           "true",

--- a/cmd/box/boxpkg/utils.go
+++ b/cmd/box/boxpkg/utils.go
@@ -263,7 +263,7 @@ func (c *client) startContainer(klconfHash string) (string, error) {
 			fmt.Sprintf("KL_HASH_FILE=/.cache/kl/box-hash/%s", boxhashFileName),
 			fmt.Sprintf("SSH_PORT=%d", sshPort),
 			fmt.Sprintf("KL_WORKSPACE=%s", c.cwd),
-			"KLCONFIG_PATH=/workspace/kl.yml",
+			"KLCONFIG_PATH=/home/kl/workspace/kl.yml",
 			fmt.Sprintf("KL_DNS=%s", constants.KLDNS),
 			fmt.Sprintf("KL_BASE_URL=%s", constants.BaseURL),
 			fmt.Sprintf("KL_HOST_USER=%s", hostName),
@@ -291,7 +291,7 @@ func (c *client) startContainer(klconfHash string) (string, error) {
 			for _, m := range vmounts {
 				binds = append(binds, fmt.Sprintf("%s:%s:z", m.Source, m.Target))
 			}
-			binds = append(binds, fmt.Sprintf("%s:/workspace:z", c.cwd))
+			binds = append(binds, fmt.Sprintf("%s:/home/kl/workspace:z", c.cwd))
 			return binds
 		}(),
 	}, &network.NetworkingConfig{
@@ -450,7 +450,7 @@ func (c *client) generateMounts() ([]mount.Mount, error) {
 
 	akTmpPath := path.Join(td, "authorized_keys")
 
-	//gitConfigPath := path.Join(userHomeDir, ".gitconfig")
+	gitConfigPath := path.Join(userHomeDir, ".gitconfig")
 
 	akByte, err = os.ReadFile(path.Join(userHomeDir, ".ssh", "authorized_keys"))
 	if err == nil {
@@ -512,10 +512,10 @@ func (c *client) generateMounts() ([]mount.Mount, error) {
 		{Type: mount.TypeVolume, Source: "kl-nix-store", Target: "/nix"},
 		{Type: mount.TypeBind, Source: configFolder, Target: "/.cache/kl"},
 	}
-	//_, err = os.Stat(gitConfigPath)
-	//if err == nil {
-	//	volumes = append(volumes, mount.Mount{Type: mount.TypeBind, Source: gitConfigPath, Target: "/tmp/gitconfig/.gitconfig", ReadOnly: true})
-	//}
+	_, err = os.Stat(gitConfigPath)
+	if err == nil {
+		volumes = append(volumes, mount.Mount{Type: mount.TypeBind, Source: gitConfigPath, Target: "/home/kl/.gitconfig", ReadOnly: true})
+	}
 
 	dockerSock := "/var/run/docker.sock"
 	// if runtime.GOOS == constants.RuntimeWindows {

--- a/klbox-docker/.profile
+++ b/klbox-docker/.profile
@@ -66,4 +66,4 @@ if [ -f "/kl-tmp/global-profile" ]; then
   source /kl-tmp/global-profile
 fi
 
-cd /workspace || return
+cd /home/kl/workspace || return

--- a/klbox-docker/.zshrc
+++ b/klbox-docker/.zshrc
@@ -77,4 +77,4 @@ precmd() {
 TMOUT=1
 
 # go to workspace
-cd /workspace
+cd /home/kl/workspace

--- a/klbox-docker/start.sh
+++ b/klbox-docker/start.sh
@@ -100,18 +100,14 @@ sudo sh -c "echo \"search $KL_SEARCH_DOMAIN\" >> $RESOLV_FILE"
 
 # sudo cp /tmp/resolv.conf /etc/resolv.conf
 
-if [ -d "/tmp/ssh2" ]; then
-  mkdir -p /home/kl/.ssh
-  cp /tmp/ssh2/authorized_keys /home/kl/.ssh/authorized_keys
-  cp /tmp/ssh2/id_rsa /home/kl/.ssh/id_rsa
-  cp /tmp/ssh2/id_rsa.pub /home/kl/.ssh/id_rsa.pub
-  chmod 600 /home/kl/.ssh/authorized_keys
-  echo "successfully copied ssh credentials"
-fi
-
-# if [ -f "/tmp/gitconfig/.gitconfig" ]; then
-#     cp /tmp/gitconfig/.gitconfig /home/kl/.gitconfig
-# fi
+#if [ -d "/tmp/ssh2" ]; then
+#  mkdir -p /home/kl/.ssh
+#  cp /tmp/ssh2/authorized_keys /home/kl/.ssh/authorized_keys
+#  cp /tmp/ssh2/id_rsa /home/kl/.ssh/id_rsa
+#  cp /tmp/ssh2/id_rsa.pub /home/kl/.ssh/id_rsa.pub
+#  chmod 600 /home/kl/.ssh/authorized_keys
+#  echo "successfully copied ssh credentials"
+#fi
 
 bash ~/.check-online >/dev/null 2>&1 &
 


### PR DESCRIPTION
To avoid conflicts with permission when mounting folders. box container should run with user id and user group of current user.

## Summary by Sourcery

New Features:
- Ensure Docker container runs with the current user's UID and GID to prevent permission conflicts when mounting folders.