### PR TITLE
Ref/cluster

### DIFF
--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -2,8 +2,6 @@ package auth
 
 import (
 	"fmt"
-	"github.com/kloudlite/kl/cmd/use"
-
 	"github.com/kloudlite/kl/constants"
 	"github.com/kloudlite/kl/domain/apiclient"
 	"github.com/kloudlite/kl/domain/fileclient"
@@ -79,10 +77,10 @@ var loginCmd = &cobra.Command{
 			return
 		}
 
-		if err = use.UseTeam(cmd); err != nil {
-			fn.PrintError(err)
-			return
-		}
+		//if err = use.UseTeam(cmd); err != nil {
+		//	fn.PrintError(err)
+		//	return
+		//}
 
 		fn.Log("successfully logged in\n")
 	},

--- a/cmd/box/boxpkg/start.go
+++ b/cmd/box/boxpkg/start.go
@@ -70,7 +70,7 @@ func (c *client) Start() error {
 	if err != nil {
 		return fn.NewE(err)
 	}
-	if data.SelectedTeam != c.klfile.TeamName {
+	if data.SelectedTeam != c.klfile.TeamName && data.SelectedTeam != "" {
 		functions.Logf(text.Yellow(fmt.Sprintf("[#] this will switch your main team context from %s to %s. do you want to proceed? [Y/n] ", data.SelectedTeam, c.klfile.TeamName)))
 		if !functions.Confirm("y", "y") {
 			return nil
@@ -91,15 +91,22 @@ func (c *client) Start() error {
 			return err
 		}
 
-		_, err = c.apic.GetAccVPNConfig(c.klfile.TeamName)
-		if err != nil {
-			return err
-		}
+	}
 
+	_, err = c.apic.GetAccVPNConfig(c.klfile.TeamName)
+	if err != nil {
+		return err
 	}
 
 	_, err = c.startContainer(boxHash.KLConfHash)
 	if err != nil {
+		return fn.NewE(err)
+	}
+
+	if err = c.SyncProxy(ProxyConfig{
+		ExposedPorts:        c.klfile.Ports,
+		TargetContainerPath: c.cwd,
+	}); err != nil {
 		return fn.NewE(err)
 	}
 

--- a/cmd/cluster/cluster.go
+++ b/cmd/cluster/cluster.go
@@ -16,12 +16,12 @@ func init() {
 
 	upCmd.Aliases = append(upCmd.Aliases, "start", "connect")
 	downCmd.Aliases = append(downCmd.Aliases, "stop", "disconnect")
-	// cleanCmd.Aliases = append(cleanCmd.Aliases, "delete", "clean")
+	cleanCmd.Aliases = append(cleanCmd.Aliases, "delete", "clean")
 
 	fileclient.OnlyOutsideBox(upCmd)
 	fileclient.OnlyOutsideBox(downCmd)
-	// fileclient.OnlyOutsideBox(cleanCmd)
+	fileclient.OnlyOutsideBox(cleanCmd)
 	Cmd.AddCommand(downCmd)
 	Cmd.AddCommand(upCmd)
-	// Cmd.AddCommand(cleanCmd)
+	Cmd.AddCommand(cleanCmd)
 }

--- a/cmd/cluster/up.go
+++ b/cmd/cluster/up.go
@@ -1,10 +1,14 @@
 package cluster
 
 import (
+	"fmt"
+	"github.com/kloudlite/kl/domain/apiclient"
 	"github.com/kloudlite/kl/domain/fileclient"
 	"github.com/kloudlite/kl/k3s"
 	"github.com/kloudlite/kl/pkg/functions"
+	"github.com/kloudlite/kl/pkg/ui/fzf"
 	"github.com/kloudlite/kl/pkg/ui/spinner"
+	"github.com/kloudlite/kl/pkg/ui/text"
 	"github.com/spf13/cobra"
 	"os"
 )
@@ -23,16 +27,33 @@ var upCmd = &cobra.Command{
 
 func startK3sServer(cmd *cobra.Command) error {
 	defer spinner.Client.UpdateMessage("starting k3s server")()
+
 	fc, err := fileclient.New()
 	if err != nil {
 		return functions.NewE(err)
 	}
-	currentTeam, err := fc.CurrentTeamName()
+
+	apic, err := apiclient.New()
 	if err != nil {
 		return functions.NewE(err)
 	}
+
+	k, err := k3s.NewClient(cmd)
+	if err != nil {
+		return functions.NewE(err)
+	}
+
+	teamName, err := k.CheckK3sServerRunning()
+	if err != nil {
+		return functions.NewE(err)
+	}
+
 	extraData, err := fileclient.GetExtraData()
 	if (err != nil && os.IsNotExist(err)) || extraData.SelectedTeam == "" {
+		currentTeam, err := fc.CurrentTeamName()
+		if err != nil {
+			return functions.NewE(err)
+		}
 		extraData.SelectedTeam = currentTeam
 		if err := fileclient.SaveExtraData(extraData); err != nil {
 			return functions.NewE(err)
@@ -41,10 +62,57 @@ func startK3sServer(cmd *cobra.Command) error {
 		return functions.NewE(err)
 	}
 
-	k, err := k3s.NewClient(cmd)
-	if err != nil {
-		return functions.NewE(err)
+	if extraData.SelectedTeam == "" {
+
+		teams, err := apic.ListTeams()
+		if err != nil {
+			return functions.NewE(err)
+		}
+
+		var selectedTeam *apiclient.Team
+
+		if len(teams) == 0 {
+			return functions.Error("no teams found")
+		} else if len(teams) == 1 {
+			selectedTeam = &teams[0]
+		} else {
+			selectedTeam, err = fzf.FindOne(teams, func(item apiclient.Team) string {
+				return item.Metadata.Name
+			}, fzf.WithPrompt("Select team to use >"))
+			if err != nil {
+				return err
+			}
+		}
+
+		//if selectedTeam.Metadata.Name != extraData.SelectedTeam && extraData.SelectedTeam != "" {
+		//	if err := StopK3sServer(cmd); err != nil {
+		//		return functions.NewE(err)
+		//	}
+		//}
+
+		extraData.SelectedTeam = selectedTeam.Metadata.Name
+
+		err = fileclient.SaveExtraData(extraData)
+		if err != nil {
+			return functions.NewE(err)
+		}
 	}
+
+	if extraData.SelectedTeam != teamName && teamName != "" && extraData.SelectedTeam != "" {
+		functions.Logf(text.Yellow(fmt.Sprintf("[#] local cluster is already running for team %s, do you want to stop it and start a new cluster for team %s? [y/N] ", teamName, extraData.SelectedTeam)))
+		if !functions.Confirm("Y", "N") {
+			return nil
+		}
+		if err := StopK3sServer(cmd); err != nil {
+			return functions.NewE(err)
+		}
+	}
+
+	_, err = apic.GetClusterConfig(extraData.SelectedTeam)
+	if err != nil {
+		return err
+	}
+
 	if err = k.CreateClustersTeams(extraData.SelectedTeam); err != nil {
 		return functions.NewE(err)
 	}

--- a/cmd/runner/init.go
+++ b/cmd/runner/init.go
@@ -42,7 +42,7 @@ var InitCommand = &cobra.Command{
 		}
 
 		if _, err = fc.GetKlFile(""); err == nil {
-			fn.Printf(text.Yellow("workspace is already initilized. Do you want to override? (y/N): "))
+			fn.Printf(text.Yellow("workspace is already initilized. Do you want to override? [y/N]: "))
 			if !fn.Confirm("Y", "N") {
 				return
 			}

--- a/cmd/status/status.go
+++ b/cmd/status/status.go
@@ -71,39 +71,39 @@ var Cmd = &cobra.Command{
 		fn.Log(text.Bold("Cluster Status"))
 
 		config, err := fc.GetClusterConfig(data.SelectedTeam)
-		if err != nil {
-			if os.IsNotExist(err) {
-				fn.Log(text.Yellow("cluster not found"))
-				return
+		if err == nil {
+			fn.Log("Name: ", text.Blue(config.ClusterName))
+
+			k3sStatus, _ := k3sClient.CheckK3sRunningLocally()
+			if k3sStatus {
+				fn.Log("Running: ", text.Green("true"))
 			} else {
-				fn.PrintError(err)
-				return
+				fn.Log("Running ", text.Yellow("false"))
 			}
-		}
-		fn.Log("Name: ", text.Blue(config.ClusterName))
 
-		k3sStatus, _ := k3sClient.CheckK3sRunningLocally()
-		if k3sStatus {
-			fn.Log("Running: ", text.Green("true"))
-		} else {
-			fn.Log("Running ", text.Yellow("false"))
-		}
-
-		k3sTracker, err := fc.GetK3sTracker()
-		if err != nil {
-			if flags.IsVerbose {
-				fn.PrintError(err)
-			}
-			fn.Log("Local Cluster: ", text.Yellow("not ready"))
-			fn.Log("Edge Connection:", text.Yellow("offline"))
-		} else {
-			err = getClusterK3sStatus(k3sTracker)
+			k3sTracker, err := fc.GetK3sTracker()
 			if err != nil {
 				if flags.IsVerbose {
 					fn.PrintError(err)
 				}
 				fn.Log("Local Cluster: ", text.Yellow("not ready"))
 				fn.Log("Edge Connection:", text.Yellow("offline"))
+			} else {
+				err = getClusterK3sStatus(k3sTracker)
+				if err != nil {
+					if flags.IsVerbose {
+						fn.PrintError(err)
+					}
+					fn.Log("Local Cluster: ", text.Yellow("not ready"))
+					fn.Log("Edge Connection:", text.Yellow("offline"))
+				}
+			}
+		}
+		if err != nil {
+			if os.IsNotExist(err) {
+				fn.Log(text.Yellow("cluster not found"))
+			} else {
+				fn.PrintError(err)
 			}
 		}
 

--- a/cmd/use/account.go
+++ b/cmd/use/account.go
@@ -64,15 +64,15 @@ func UseTeam(cmd *cobra.Command) error {
 		return fn.NewE(err)
 	}
 
-	_, err = apic.GetClusterConfig(selectedTeam.Metadata.Name)
-	if err != nil {
-		return err
-	}
-
-	_, err = apic.GetAccVPNConfig(selectedTeam.Metadata.Name)
-	if err != nil {
-		return err
-	}
+	//_, err = apic.GetClusterConfig(selectedTeam.Metadata.Name)
+	//if err != nil {
+	//	return err
+	//}
+	//
+	//_, err = apic.GetAccVPNConfig(selectedTeam.Metadata.Name)
+	//if err != nil {
+	//	return err
+	//}
 
 	//k, err := cluster.NewClient()
 	//if err != nil {

--- a/k3s/impl.go
+++ b/k3s/impl.go
@@ -248,7 +248,12 @@ func (c *client) generateConnectionScript(clusterConfig *fileclient.TeamClusterC
 
 	vpnTeamConfig, err := c.fc.GetVpnTeamConfig(teamName)
 	if err != nil {
-		return "", err
+		if !os.IsNotExist(err) {
+			return "", nil
+		}
+		vpnTeamConfig = &fileclient.TeamVpnConfig{
+			IpAddress: "",
+		}
 	}
 
 	cc := struct {

--- a/k3s/impl.go
+++ b/k3s/impl.go
@@ -667,3 +667,22 @@ func (c *client) RemoveClusterVolume(clusterName string) error {
 	}
 	return nil
 }
+
+func (c *client) CheckK3sServerRunning() (string, error) {
+	crlist, err := c.c.ContainerList(c.cmd.Context(), container.ListOptions{
+		Filters: filters.NewArgs(
+			filters.Arg("label", fmt.Sprintf("%s=%s", CONT_MARK_KEY, "true")),
+			filters.Arg("label", fmt.Sprintf("%s=%s", "kl-k3s", "true")),
+		),
+		All: true,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	if len(crlist) > 0 {
+		return crlist[0].Labels["kl-team"], nil
+	}
+
+	return "", nil
+}

--- a/k3s/main.go
+++ b/k3s/main.go
@@ -17,6 +17,7 @@ type K3sClient interface {
 	DeletePods() error
 	CheckK3sRunningLocally() (bool, error)
 	RemoveClusterVolume(clusterName string) error
+	CheckK3sServerRunning() (string, error)
 }
 
 type client struct {

--- a/klbox-docker/start.sh
+++ b/klbox-docker/start.sh
@@ -28,17 +28,28 @@ chown -R kl /kl-tmp/global-profile
 mkdir -p /etc/wireguard
 echo $KL_TEAM_NAME
 set -x
-CLUSTER_IP_RANGE=$(echo $CLUSTER_IP_RANGE | sed 's/\//###/g')
-cat /.cache/kl/kl-workspace-wg.conf | sed "s/#CLUSTER_GATEWAY_IP/${CLUSTER_GATEWAY_IP:-null}/" | sed "s/#CLUSTER_IP_RANGE/${CLUSTER_IP_RANGE:-null}/" >/tmp/wg-cong
-sed -i "s/###/\//" /tmp/wg-cong
-set +x
-sudo cp /tmp/wg-cong /etc/wireguard/kl-workspace-wg.conf
-rm /tmp/wg-cong
+
+if [[ -n "${CLUSTER_GATEWAY_IP}" && -n "${CLUSTER_IP_RANGE}" ]]; then
+    CLUSTER_IP_RANGE=$(echo $CLUSTER_IP_RANGE | sed 's/\//###/g')
+
+    cat /.cache/kl/kl-workspace-wg.conf | \
+        sed "s/#CLUSTER_GATEWAY_IP/${CLUSTER_GATEWAY_IP:-null}/" | \
+        sed "s/#CLUSTER_IP_RANGE/${CLUSTER_IP_RANGE:-null}/" >/tmp/wg-cong
+
+    sed -i "s/###/\//" /tmp/wg-cong
+
+    sudo cp /tmp/wg-cong /etc/wireguard/kl-workspace-wg.conf
+    rm /tmp/wg-cong
+
+    sudo wg-quick up kl-workspace-wg
+fi
+
 cat /.cache/kl/vpn/${KL_TEAM_NAME}.json | jq -r .wg | base64 -d >/tmp/kl-vpn.conf
 sudo cp /tmp/kl-vpn.conf /etc/wireguard/kl-vpn.conf
 rm /tmp/kl-vpn.conf
 sudo wg-quick up kl-vpn
-sudo wg-quick up kl-workspace-wg
+set +x
+
 
 entrypoint_executed="/home/kl/.kloudlite_entrypoint_executed"
 if [ ! -f "$entrypoint_executed" ]; then


### PR DESCRIPTION
## Summary by Sourcery

Refactor the cluster management commands to improve team selection and environment configuration. Enhance the cluster status output for better clarity on the running state and connection status. Enable the clean command in the cluster command setup.

Enhancements:
- Improve team selection logic in the startK3sServer function to handle multiple teams and prompt user selection when necessary.
- Refactor environment variable setup in the startContainer function to dynamically include cluster configuration if available.
- Enhance the cluster status command to provide more detailed output about the cluster's running state and connection status.

Chores:
- Uncomment and enable the clean command in the cluster command setup.