### PR TITLE
:bug: fixed issue with podman user namespace

### DIFF
--- a/klbox-docker/docker-socket.sh
+++ b/klbox-docker/docker-socket.sh
@@ -1,22 +1,23 @@
 #! /usr/bin/env bash
 
 if [ $(id -u) -ne 0 ]; then
-	echo "This script must be run as root"
-	exit 1
+  echo "This script must be run as root"
+  exit 1
 fi
 
 HOST_DOCKER_SOCKET=/var/run/host-docker.sock
 
 rm -f /var/run/docker.sock
+
 socat UNIX-LISTEN:/var/run/docker.sock,fork,reuseaddr UNIX-CONNECT:$HOST_DOCKER_SOCKET &
 pid=$!
 
 while true; do
-	if [ -x /var/run/docker.sock ]; then
-		chown kl /var/run/docker.sock
-		break
-	fi
-	sleep 1
+  if [ -x /var/run/docker.sock ]; then
+    chown kl /var/run/docker.sock
+    break
+  fi
+  sleep 1
 done
 
 wait $pid

--- a/klbox-docker/entrypoint.sh
+++ b/klbox-docker/entrypoint.sh
@@ -5,11 +5,6 @@ set -o pipefail
 
 /docker-socket.sh &
 
-usermod -u $HOST_USER_UID kl
-#usermod -g $HOST_USER_GID kl
-chown -R kl:kl /kl-tmp
-chown -R kl:kl /nix
-
 /start.sh
 
 export SSH_PORT=$SSH_PORT

--- a/klbox-docker/start.sh
+++ b/klbox-docker/start.sh
@@ -63,7 +63,7 @@ if [ ! -f "$entrypoint_executed" ]; then
   # ssh-keygen -t rsa -b 4096 -f ~/.ssh/id_rsa -N "" <<<y >/dev/null 2>&1
 fi
 
-chown -R kl /home/kl/
+# chown -R kl /home/kl/
 sudo -u kl mkdir -p /home/kl/.config/nix
 sudo -u kl echo "experimental-features = nix-command flakes" >/home/kl/.config/nix/nix.conf
 


### PR DESCRIPTION
## Summary by Sourcery

Fix issue with Podman user namespace by setting UsernsMode to 'keep-id' and refactor volume binding logic to use mount.Mount for improved flexibility. Enhance docker socket handling by dynamically determining the socket path based on the DOCKER_HOST environment variable.

Bug Fixes:
- Fix issue with Podman user namespace by setting UsernsMode to 'keep-id' in container configuration.

Enhancements:
- Refactor volume binding logic to use mount.Mount instead of string-based binds for better flexibility and clarity.
- Improve docker socket handling by dynamically determining the socket path based on the DOCKER_HOST environment variable.