### PR TITLE
Issue/removing docker sock

### DIFF
--- a/clis/kl/loadsubs.go
+++ b/clis/kl/loadsubs.go
@@ -16,6 +16,7 @@ import (
 	set_base_url "github.com/kloudlite/kl/cmd/set-base-url"
 	"github.com/kloudlite/kl/cmd/status"
 	"github.com/kloudlite/kl/cmd/use"
+	"github.com/kloudlite/kl/domain/fileclient"
 	"github.com/kloudlite/kl/flags"
 	"github.com/spf13/cobra"
 )
@@ -47,6 +48,7 @@ func init() {
 	rootCmd.AddCommand(cluster.Cmd)
 	rootCmd.AddCommand(expose.Cmd)
 
+	fileclient.OnlyInsideBox(add.Command)
 	rootCmd.AddCommand(add.Command)
 	rootCmd.AddCommand(status.Cmd)
 	rootCmd.AddCommand(packages.Cmd)

--- a/clis/kl/loadsubs.go
+++ b/clis/kl/loadsubs.go
@@ -6,6 +6,7 @@ import (
 	"github.com/kloudlite/kl/cmd/clone"
 	"github.com/kloudlite/kl/cmd/cluster"
 	"github.com/kloudlite/kl/cmd/connect"
+	"github.com/kloudlite/kl/cmd/env"
 	"github.com/kloudlite/kl/cmd/expose"
 	"github.com/kloudlite/kl/cmd/get"
 	"github.com/kloudlite/kl/cmd/intercept"
@@ -16,7 +17,6 @@ import (
 	set_base_url "github.com/kloudlite/kl/cmd/set-base-url"
 	"github.com/kloudlite/kl/cmd/status"
 	"github.com/kloudlite/kl/cmd/use"
-	"github.com/kloudlite/kl/domain/fileclient"
 	"github.com/kloudlite/kl/flags"
 	"github.com/spf13/cobra"
 )
@@ -39,6 +39,7 @@ func init() {
 
 	rootCmd.AddCommand(use.Cmd)
 	rootCmd.AddCommand(clone.Cmd)
+	rootCmd.AddCommand(env.Cmd)
 	rootCmd.AddCommand(runner.InitCommand)
 	rootCmd.AddCommand(set_base_url.Cmd)
 
@@ -48,7 +49,6 @@ func init() {
 	rootCmd.AddCommand(cluster.Cmd)
 	rootCmd.AddCommand(expose.Cmd)
 
-	fileclient.OnlyInsideBox(add.Command)
 	rootCmd.AddCommand(add.Command)
 	rootCmd.AddCommand(status.Cmd)
 	rootCmd.AddCommand(packages.Cmd)

--- a/cmd/box/boxpkg/restart.go
+++ b/cmd/box/boxpkg/restart.go
@@ -2,6 +2,7 @@ package boxpkg
 
 import (
 	"fmt"
+
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
 	"github.com/kloudlite/kl/domain/envclient"
@@ -10,17 +11,12 @@ import (
 )
 
 func (c *client) Restart() error {
-
 	if envclient.InsideBox() {
 		fn.Logf(text.Yellow("[#] this will restart current workspace and action will terminate all the processes running in the container. do you want to proceed? [Y/n] "))
 		if !fn.Confirm("y", "y") {
 			return fn.NewE(fn.NewE(UserCanceled))
 		}
-		path, err := envclient.GetWorkspacePath()
-		if err != nil {
-			return err
-		}
-		return c.restartContainer(path)
+		return c.restartContainer()
 	}
 	return c.restartBoxContainer()
 }

--- a/cmd/box/boxpkg/utils.go
+++ b/cmd/box/boxpkg/utils.go
@@ -13,7 +13,6 @@ import (
 	"path"
 	"runtime"
 	"strconv"
-	"strings"
 	"text/template"
 	"time"
 
@@ -138,37 +137,12 @@ func (c *client) ensureImage(i string) error {
 	return nil
 }
 
-func (c *client) restartContainer(path string) error {
+func (c *client) restartContainer() error {
 	defer spinner.Client.UpdateMessage("restart container")()
-
-	existingContainers, err := c.cli.ContainerList(context.Background(), container.ListOptions{
-		Filters: filters.NewArgs(
-			dockerLabelFilter(CONT_MARK_KEY, "true"),
-			dockerLabelFilter(CONT_WORKSPACE_MARK_KEY, "true"),
-			dockerLabelFilter(CONT_PATH_KEY, path),
-		),
-		All: true,
-	})
-	if len(existingContainers) == 0 {
-		return nil
+	cmd := exec.Command("bash", "/kl-tmp/kill-sshd.sh")
+	if err := cmd.Run(); err != nil {
+		return fn.NewE(err, "failed to kill sshd")
 	}
-
-	if err != nil {
-		return fn.NewE(err, "failed to list containers")
-	}
-
-	if err := os.RemoveAll("/tmp/kl"); err != nil {
-		return fn.NewE(err)
-	}
-
-	timeOut := 0
-	if err := c.cli.ContainerRestart(context.Background(), existingContainers[0].ID, container.StopOptions{
-		Signal:  "SIGKILL",
-		Timeout: &timeOut,
-	}); err != nil {
-		return fn.NewE(err)
-	}
-
 	return nil
 }
 
@@ -257,6 +231,9 @@ func (c *client) startContainer(klconfHash string) (string, error) {
 	}
 
 	clusterConfig, err := c.fc.GetClusterConfig(currentSystemConfig.SelectedTeam)
+	if err != nil {
+		return "", fn.NewE(err)
+	}
 
 	env := []string{
 		fmt.Sprintf("KL_HASH_FILE=/.cache/kl/box-hash/%s", boxhashFileName),
@@ -295,7 +272,10 @@ func (c *client) startContainer(klconfHash string) (string, error) {
 		ExtraHosts: []string{
 			fmt.Sprintf("k3s-cluster.local:%s", constants.K3sServerIp),
 		},
-		Privileged:  true,
+		Privileged: true,
+		RestartPolicy: container.RestartPolicy{
+			Name: container.RestartPolicyAlways,
+		},
 		NetworkMode: "kloudlite",
 		PortBindings: nat.PortMap{
 			nat.Port(fmt.Sprintf("%d/tcp", sshPort)): []nat.PortBinding{
@@ -542,11 +522,8 @@ func (c *client) generateMounts() ([]mount.Mount, error) {
 
 	volumes := []mount.Mount{
 		{Type: mount.TypeVolume, Source: "kl-home-cache", Target: "/home"},
-		//{Type: mount.TypeBind, Source: rsaPath, Target: "/tmp/ssh2/id_rsa", ReadOnly: true},
-		//  NOTE: never change the order of ssh mount
 		{Type: mount.TypeBind, Source: sshDir, Target: "/home/kl/.ssh", ReadOnly: true},
 		{Type: mount.TypeBind, Source: akTmpPath, Target: "/home/kl/.ssh/authorized_keys", ReadOnly: true},
-		//{Type: mount.TypeBind, Source: gitConfigPath, Target: "/tmp/gitconfig/.gitconfig", ReadOnly: true},
 		{Type: mount.TypeVolume, Source: "kl-nix-store", Target: "/nix"},
 		{Type: mount.TypeBind, Source: configFolder, Target: "/.cache/kl"},
 	}
@@ -555,30 +532,26 @@ func (c *client) generateMounts() ([]mount.Mount, error) {
 		volumes = append(volumes, mount.Mount{Type: mount.TypeBind, Source: gitConfigPath, Target: "/home/kl/.gitconfig", ReadOnly: true})
 	}
 
-	dockerSock := func() string {
-		if s := os.Getenv("DOCKER_HOST"); s != "" {
-			return s
-		}
+	// dockerSock := func() string {
+	// 	if s := os.Getenv("DOCKER_HOST"); s != "" {
+	// 		return s
+	// 	}
 
-		return "unix:///var/run/docker.sock"
-	}()
+	// 	return "unix:///var/run/docker.sock"
+	// }()
 
-	dockerSockPath := func() string {
-		// extract the path from the docker sock url
-		if strings.HasPrefix(dockerSock, "unix://") {
-			return strings.TrimPrefix(dockerSock, "unix://")
-		}
+	// dockerSockPath := func() string {
+	// 	// extract the path from the docker sock url
+	// 	if strings.HasPrefix(dockerSock, "unix://") {
+	// 		return strings.TrimPrefix(dockerSock, "unix://")
+	// 	}
 
-		return dockerSock
-	}()
+	// 	return dockerSock
+	// }()
 
-	// if runtime.GOOS == constants.RuntimeWindows {
-	// 	dockerSock = "\\\\.\\pipe\\docker_engine"
-	// }
-
-	volumes = append(volumes,
-		mount.Mount{Type: mount.TypeBind, Source: dockerSockPath, Target: "/var/run/host-docker.sock"},
-	)
+	// volumes = append(volumes,
+	// 	mount.Mount{Type: mount.TypeBind, Source: dockerSockPath, Target: "/var/run/host-docker.sock"},
+	// )
 
 	return volumes, nil
 }

--- a/cmd/box/boxpkg/utils.go
+++ b/cmd/box/boxpkg/utils.go
@@ -230,10 +230,8 @@ func (c *client) startContainer(klconfHash string) (string, error) {
 		}
 	}
 
-	clusterConfig, err := c.fc.GetClusterConfig(currentSystemConfig.SelectedTeam)
-	if err != nil {
-		return "", fn.NewE(err)
-	}
+	// Error is ignored here because we want to continue even if the cluster config is not found
+	clusterConfig, _ := c.fc.GetClusterConfig(currentSystemConfig.SelectedTeam)
 
 	env := []string{
 		fmt.Sprintf("KL_HASH_FILE=/.cache/kl/box-hash/%s", boxhashFileName),
@@ -301,17 +299,6 @@ func (c *client) startContainer(klconfHash string) (string, error) {
 
 			return resp
 		}(),
-		// Binds: func() []string {
-		// 	binds := make([]string, 0, len(vmounts))
-		// 	for _, m := range vmounts {
-		// 		binds = append(binds, fmt.Sprintf("%s:%s:Z", m.Source, m.Target))
-		// 	}
-		// 	binds = append(binds, fmt.Sprintf("%s:/home/kl/workspace:Z", c.cwd))
-		//
-		// 	fmt.Printf("%#v", binds)
-		//
-		// 	return binds
-		// }(),
 	}, &network.NetworkingConfig{
 		EndpointsConfig: map[string]*network.EndpointSettings{
 			"kloudlite": {
@@ -455,25 +442,9 @@ func (c *client) generateMounts() ([]mount.Mount, error) {
 		return nil, fn.NewE(err)
 	}
 
-	sshPath := path.Join(userHomeDir, ".ssh", "id_rsa.pub")
-	//rsaPath := path.Join(userHomeDir, ".ssh", "id_rsa")
 	sshDir := path.Join(userHomeDir, ".ssh")
 
-	akByte, err := os.ReadFile(sshPath)
-	if err != nil {
-		return nil, fn.NewE(err)
-	}
-
-	ak := string(akByte)
-
-	akTmpPath := path.Join(td, "authorized_keys")
-
 	gitConfigPath := path.Join(userHomeDir, ".gitconfig")
-
-	akByte, err = os.ReadFile(path.Join(userHomeDir, ".ssh", "authorized_keys"))
-	if err == nil {
-		ak += fmt.Sprint("\n", string(akByte))
-	}
 
 	// for wsl
 	if err := func() error {
@@ -497,21 +468,10 @@ func (c *client) generateMounts() ([]mount.Mount, error) {
 			if _, err := os.Stat(pth); err != nil {
 				continue
 			}
-
-			b, err := os.ReadFile(pth)
-			if err != nil {
-				return fn.NewE(err)
-			}
-
-			ak += fmt.Sprint("\n", string(b))
 		}
 
 		return nil
 	}(); err != nil {
-		return nil, fn.NewE(err)
-	}
-
-	if err := writeOnUserScope(akTmpPath, []byte(ak)); err != nil {
 		return nil, fn.NewE(err)
 	}
 
@@ -522,8 +482,7 @@ func (c *client) generateMounts() ([]mount.Mount, error) {
 
 	volumes := []mount.Mount{
 		{Type: mount.TypeVolume, Source: "kl-home-cache", Target: "/home"},
-		{Type: mount.TypeBind, Source: sshDir, Target: "/home/kl/.ssh", ReadOnly: true},
-		{Type: mount.TypeBind, Source: akTmpPath, Target: "/home/kl/.ssh/authorized_keys", ReadOnly: true},
+		{Type: mount.TypeBind, Source: sshDir, Target: "/home/kl/.ssh", ReadOnly: false},
 		{Type: mount.TypeVolume, Source: "kl-nix-store", Target: "/nix"},
 		{Type: mount.TypeBind, Source: configFolder, Target: "/.cache/kl"},
 	}

--- a/cmd/connect/connect.go
+++ b/cmd/connect/connect.go
@@ -3,7 +3,6 @@ package connect
 import (
 	"bufio"
 	"github.com/kloudlite/kl/domain/envclient"
-	"github.com/kloudlite/kl/domain/fileclient"
 	"github.com/kloudlite/kl/k3s"
 	fn "github.com/kloudlite/kl/pkg/functions"
 	"github.com/kloudlite/kl/pkg/ui/spinner"
@@ -33,89 +32,78 @@ func startWg(cmd *cobra.Command) error {
 		return fn.NewE(err)
 	}
 
-	r, _ := k3sClient.CheckK3sRunningLocally()
-	if !r {
-		if envclient.InsideBox() {
-			if err = fn.ExecNoOutput("wg-quick down kl-vpn 2> /dev/null | echo already down"); err != nil {
-				return fn.NewE(err)
-			}
-
-			if err = fn.ExecNoOutput("wg-quick up kl-vpn"); err != nil {
-				return fn.NewE(err)
-			}
-		}
-		return nil
-	}
-
-	if !envclient.InsideBox() {
-		if err := k3sClient.RestartWgProxyContainer(); err != nil {
+	if envclient.InsideBox() {
+		if err = fn.ExecNoOutput("wg-quick down kl-vpn 2> /dev/null | echo already down"); err != nil {
 			return fn.NewE(err)
 		}
+
+		if err = fn.ExecNoOutput("wg-quick up kl-vpn"); err != nil {
+			return fn.NewE(err)
+		}
+
+		if err = fn.ExecNoOutput("wg-quick down kl-workspace-wg 2> /dev/null | echo already down"); err != nil {
+			return fn.NewE(err)
+		}
+
+		if err = fn.ExecNoOutput("wg-quick up kl-workspace-wg"); err != nil {
+			return fn.NewE(err)
+		}
+
 		return nil
 	}
 
-	if err = fn.ExecNoOutput("wg-quick down kl-vpn 2> /dev/null | echo already down "); err != nil {
-		return fn.NewE(err)
-	}
+	//r, _ := k3sClient.CheckK3sRunningLocally()
+	//if !r {
+	//	if envclient.InsideBox() {
+	//		if err = fn.ExecNoOutput("wg-quick down kl-vpn 2> /dev/null | echo already down"); err != nil {
+	//			return fn.NewE(err)
+	//		}
+	//
+	//		if err = fn.ExecNoOutput("wg-quick up kl-vpn"); err != nil {
+	//			return fn.NewE(err)
+	//		}
+	//	}
+	//	return nil
+	//}
 
-	if err = fn.ExecNoOutput("wg-quick up kl-vpn"); err != nil {
-		return fn.NewE(err)
-	}
-
-	fc, err := fileclient.New()
-	if err != nil {
-		return err
-	}
-	k3sTracker, err := fc.GetK3sTracker()
-	if err == nil {
-		if ChekcWireguardConnection() && k3sTracker.WgConnection {
-			return nil
-		}
-	}
-
-	if err = fn.ExecNoOutput("wg-quick down kl-workspace-wg 2> /dev/null | echo already down"); err != nil {
-		return fn.NewE(err)
-	}
-
+	//if !envclient.InsideBox() {
 	if err := k3sClient.RestartWgProxyContainer(); err != nil {
 		return fn.NewE(err)
 	}
+	//return nil
+	//}
 
-	if err = fn.ExecNoOutput("wg-quick up kl-workspace-wg"); err != nil {
-		return fn.NewE(err)
-	}
-
-	//time.Sleep(time.Second * 1)
+	//if err = fn.ExecNoOutput("wg-quick down kl-vpn 2> /dev/null | echo already down "); err != nil {
+	//	return fn.NewE(err)
+	//}
 	//
-	//open, err := os.Open("/tmp/kl/online.status")
+	//if err = fn.ExecNoOutput("wg-quick up kl-vpn"); err != nil {
+	//	return fn.NewE(err)
+	//}
+
+	//fc, err := fileclient.New()
 	//if err != nil {
 	//	return err
 	//}
-	//
-	//if _, err := open.Seek(0, io.SeekEnd); err != nil {
-	//	return err
-	//}
-	//
-	//defer open.Close()
-	//reader := bufio.NewReader(open)
-	//
-	//startTime := time.Now()
-	//for {
-	//	<-time.After(time.Second * 1)
-	//	msg, err := reader.ReadString('\n')
-	//	if err != nil {
-	//		if time.Since(startTime) > time.Second*30 {
-	//			return nil
-	//		}
-	//		if errors.Is(err, io.EOF) {
-	//			continue
-	//		}
-	//		return err
-	//	}
-	//	if msg == "online\n" {
-	//		break
+	//k3sTracker, err := fc.GetK3sTracker()
+	//if err == nil {
+	//	if ChekcWireguardConnection() && k3sTracker.WgConnection {
+	//		return nil
 	//	}
 	//}
+
+	//if err = fn.ExecNoOutput("wg-quick down kl-workspace-wg 2> /dev/null | echo already down"); err != nil {
+	//	return fn.NewE(err)
+	//}
+	//
+	//if err := k3sClient.RestartWgProxyContainer(); err != nil {
+	//	return fn.NewE(err)
+	//}
+	//
+	//if err = fn.ExecNoOutput("wg-quick up kl-workspace-wg"); err != nil {
+	//	return fn.NewE(err)
+	//}
+
 	fn.Log(text.Green("device connected"))
 
 	return nil

--- a/cmd/env/env.go
+++ b/cmd/env/env.go
@@ -1,0 +1,15 @@
+package env
+
+import "github.com/spf13/cobra"
+
+var Cmd = &cobra.Command{
+	Use:   "env",
+	Short: "suspend and resume environment",
+}
+
+func init() {
+	Cmd.AddCommand(pauseCmd)
+	Cmd.AddCommand(resumeCmd)
+	Cmd.Aliases = append(Cmd.Aliases, "environment")
+	pauseCmd.Aliases = append(pauseCmd.Aliases, "suspend")
+}

--- a/cmd/env/pause.go
+++ b/cmd/env/pause.go
@@ -1,0 +1,59 @@
+package env
+
+import (
+	"github.com/kloudlite/kl/domain/apiclient"
+	"github.com/kloudlite/kl/domain/fileclient"
+	fn "github.com/kloudlite/kl/pkg/functions"
+	"github.com/kloudlite/kl/pkg/ui/text"
+	"github.com/spf13/cobra"
+)
+
+var pauseCmd = &cobra.Command{
+	Use:   "pause",
+	Short: "suspend environment",
+	Run: func(_ *cobra.Command, _ []string) {
+		if err := envPause(); err != nil {
+			fn.PrintError(err)
+			return
+		}
+	},
+}
+
+func envPause() error {
+
+	fc, err := fileclient.New()
+	if err != nil {
+		return err
+	}
+
+	apic, err := apiclient.New()
+	if err != nil {
+		return err
+	}
+
+	env, err := apic.EnsureEnv()
+	if err != nil {
+		return err
+	}
+
+	team, err := fc.CurrentTeamName()
+	if err != nil {
+		return err
+	}
+
+	e, err := apic.GetEnvironment(team, env.Name)
+	if err != nil {
+		return err
+	}
+
+	if !e.Status.IsReady {
+		fn.Warnf("environment is not ready, please wait for it to be ready")
+		return nil
+	}
+
+	if err := apic.UpdateEnvironment(team, e, true); err != nil {
+		return err
+	}
+	fn.Log(text.Bold(text.Green("\nEnvironment suspended successfully\n")))
+	return nil
+}

--- a/cmd/env/resume.go
+++ b/cmd/env/resume.go
@@ -1,0 +1,58 @@
+package env
+
+import (
+	"github.com/kloudlite/kl/domain/apiclient"
+	"github.com/kloudlite/kl/domain/fileclient"
+	fn "github.com/kloudlite/kl/pkg/functions"
+	"github.com/kloudlite/kl/pkg/ui/text"
+	"github.com/spf13/cobra"
+)
+
+var resumeCmd = &cobra.Command{
+	Use:   "resume",
+	Short: "resume suspended env",
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := envResume(); err != nil {
+			fn.PrintError(err)
+			return
+		}
+	},
+}
+
+func envResume() error {
+	fc, err := fileclient.New()
+	if err != nil {
+		return err
+	}
+
+	apic, err := apiclient.New()
+	if err != nil {
+		return err
+	}
+
+	env, err := apic.EnsureEnv()
+	if err != nil {
+		return err
+	}
+
+	team, err := fc.CurrentTeamName()
+	if err != nil {
+		return err
+	}
+
+	e, err := apic.GetEnvironment(team, env.Name)
+	if err != nil {
+		return err
+	}
+
+	if !e.Status.IsReady {
+		fn.Warnf("environment is not ready, please wait for it to be ready")
+		return nil
+	}
+
+	if err := apic.UpdateEnvironment(team, e, false); err != nil {
+		return err
+	}
+	fn.Log(text.Bold(text.Green("\nEnvironment resumed successfully\n")))
+	return nil
+}

--- a/cmd/list/env.go
+++ b/cmd/list/env.go
@@ -55,15 +55,27 @@ func listEnvironments(cmd *cobra.Command, args []string) error {
 		envName = env.Name
 	}
 
-	header := table.Row{table.HeaderText("Display Name"), table.HeaderText("Name"), table.HeaderText("ready")}
+	header := table.Row{table.HeaderText("Display Name"), table.HeaderText("Name"), table.HeaderText("status")}
 	rows := make([]table.Row, 0)
 
 	for _, a := range envs {
-		rows = append(rows, table.Row{
-			fn.GetPrintRow(a, envName, a.DisplayName, true),
-			fn.GetPrintRow(a, envName, a.Metadata.Name),
-			fn.GetPrintRow(a, envName, a.Status.IsReady),
-		})
+		status := text.Yellow("not ready")
+		if a.Status.IsReady {
+			status = text.Green("ready")
+		}
+		if a.ClusterName == "" {
+			rows = append(rows, table.Row{
+				fn.GetPrintRow(a, envName, a.DisplayName, true),
+				fn.GetPrintRow(a, envName, a.Metadata.Name+" (template)"),
+				fn.GetPrintRow(a, envName, status),
+			})
+		} else {
+			rows = append(rows, table.Row{
+				fn.GetPrintRow(a, envName, a.DisplayName),
+				fn.GetPrintRow(a, envName, a.Metadata.Name),
+				fn.GetPrintRow(a, envName, status),
+			})
+		}
 	}
 
 	fn.Println(table.Table(&header, rows, cmd))

--- a/cmd/list/env.go
+++ b/cmd/list/env.go
@@ -2,6 +2,7 @@ package list
 
 import (
 	"github.com/kloudlite/kl/pkg/ui/text"
+	"time"
 
 	"github.com/kloudlite/kl/domain/apiclient"
 	"github.com/kloudlite/kl/domain/fileclient"
@@ -57,19 +58,30 @@ func listEnvironments(cmd *cobra.Command, args []string) error {
 
 	header := table.Row{table.HeaderText("Display Name"), table.HeaderText("Name"), table.HeaderText("status")}
 	rows := make([]table.Row, 0)
-
 	for _, a := range envs {
-		status := text.Yellow("not ready")
-		if a.Status.IsReady {
-			status = text.Green("ready")
-		}
+		status := "offline"
 		if a.ClusterName == "" {
+			status = "-"
 			rows = append(rows, table.Row{
 				fn.GetPrintRow(a, envName, a.DisplayName, true),
 				fn.GetPrintRow(a, envName, a.Metadata.Name+" (template)"),
 				fn.GetPrintRow(a, envName, status),
 			})
 		} else {
+			if a.IsArchived {
+				status = "archived"
+			} else {
+				cluster, err := apic.GetCluster(currentTeam, a.ClusterName)
+				if err != nil {
+					return functions.NewE(err)
+				}
+				if time.Since(cluster.LastOnlineAt) < time.Minute {
+					status = "online"
+				}
+				if a.Spec.Suspend {
+					status = "suspended"
+				}
+			}
 			rows = append(rows, table.Row{
 				fn.GetPrintRow(a, envName, a.DisplayName),
 				fn.GetPrintRow(a, envName, a.Metadata.Name),

--- a/cmd/runner/add/add-config.go
+++ b/cmd/runner/add/add-config.go
@@ -55,7 +55,7 @@ func selectAndAddConfig(cmd *cobra.Command, args []string) error {
 	}
 
 	if filePath == "" {
-		filePath = "/home/kl/workspace/"
+		filePath = "/home/kl/workspace/kl.yml"
 	}
 
 	klFile, err := fc.GetKlFile(filePath)

--- a/cmd/runner/add/add-config.go
+++ b/cmd/runner/add/add-config.go
@@ -54,6 +54,10 @@ func selectAndAddConfig(cmd *cobra.Command, args []string) error {
 		name = args[0]
 	}
 
+	if filePath == "" {
+		filePath = "/home/kl/workspace/"
+	}
+
 	klFile, err := fc.GetKlFile(filePath)
 	if err != nil {
 		return fn.NewE(err)

--- a/cmd/runner/add/add-mres.go
+++ b/cmd/runner/add/add-mres.go
@@ -49,7 +49,7 @@ func AddMres(apic apiclient.ApiClient, fc fileclient.FileClient, cmd *cobra.Comm
 
 	filePath := fn.ParseKlFile(cmd)
 	if filePath == "" {
-		filePath = "/home/kl/workspace/"
+		filePath = "/home/kl/workspace/kl.yml"
 	}
 	kt, err := fc.GetKlFile(filePath)
 	if err != nil {

--- a/cmd/runner/add/add-mres.go
+++ b/cmd/runner/add/add-mres.go
@@ -48,6 +48,9 @@ This command will add secret entry of managed resource references from current e
 func AddMres(apic apiclient.ApiClient, fc fileclient.FileClient, cmd *cobra.Command, args []string) error {
 
 	filePath := fn.ParseKlFile(cmd)
+	if filePath == "" {
+		filePath = "/home/kl/workspace/"
+	}
 	kt, err := fc.GetKlFile(filePath)
 	if err != nil {
 		return fn.NewE(err)

--- a/cmd/runner/add/add-secret.go
+++ b/cmd/runner/add/add-secret.go
@@ -54,7 +54,7 @@ func selectAndAddSecret(cmd *cobra.Command, args []string) error {
 	}
 
 	if filePath == "" {
-		filePath = "/home/kl/workspace/"
+		filePath = "/home/kl/workspace/kl.yml"
 	}
 
 	klFile, err := fc.GetKlFile(filePath)

--- a/cmd/runner/add/add-secret.go
+++ b/cmd/runner/add/add-secret.go
@@ -53,6 +53,10 @@ func selectAndAddSecret(cmd *cobra.Command, args []string) error {
 		name = args[0]
 	}
 
+	if filePath == "" {
+		filePath = "/home/kl/workspace/"
+	}
+
 	klFile, err := fc.GetKlFile(filePath)
 	if err != nil {
 		return fn.NewE(err)

--- a/cmd/runner/add/add.go
+++ b/cmd/runner/add/add.go
@@ -1,6 +1,7 @@
 package add
 
 import (
+	"github.com/kloudlite/kl/domain/fileclient"
 	"github.com/spf13/cobra"
 )
 
@@ -11,6 +12,12 @@ var Command = &cobra.Command{
 }
 
 func init() {
+	fileclient.OnlyInsideBox(confCmd)
+	fileclient.OnlyInsideBox(mresCmd)
+	fileclient.OnlyInsideBox(secCmd)
+	fileclient.OnlyInsideBox(mountCommand)
+	fileclient.OnlyInsideBox(envvarCommand)
+
 	Command.AddCommand(confCmd)
 	Command.AddCommand(mresCmd)
 	Command.AddCommand(secCmd)

--- a/cmd/runner/add/envvar.go
+++ b/cmd/runner/add/envvar.go
@@ -39,7 +39,7 @@ func addEnvvar(cmd *cobra.Command, args []string) error {
 
 	filePath := fn.ParseKlFile(cmd)
 	if filePath == "" {
-		filePath = "/home/kl/workspace/"
+		filePath = "/home/kl/workspace/kl.yml"
 	}
 
 	fc, err := fileclient.New()

--- a/cmd/runner/add/envvar.go
+++ b/cmd/runner/add/envvar.go
@@ -36,6 +36,12 @@ func addEnvvar(cmd *cobra.Command, args []string) error {
 	if len(kv) != 2 {
 		return fn.Errorf("wrong envvar format use key=value")
 	}
+
+	filePath := fn.ParseKlFile(cmd)
+	if filePath == "" {
+		filePath = "/home/kl/workspace/"
+	}
+
 	fc, err := fileclient.New()
 	if err != nil {
 		return fn.NewE(err)

--- a/cmd/runner/add/mount.go
+++ b/cmd/runner/add/mount.go
@@ -44,7 +44,7 @@ var mountCommand = &cobra.Command{
 		filePath := fn.ParseKlFile(cmd)
 
 		if filePath == "" {
-			filePath = "/home/kl/workspace/"
+			filePath = "/home/kl/workspace/kl.yml"
 		}
 
 		klFile, err := fc.GetKlFile(filePath)

--- a/cmd/runner/add/mount.go
+++ b/cmd/runner/add/mount.go
@@ -42,6 +42,11 @@ var mountCommand = &cobra.Command{
 		}
 
 		filePath := fn.ParseKlFile(cmd)
+
+		if filePath == "" {
+			filePath = "/home/kl/workspace/"
+		}
+
 		klFile, err := fc.GetKlFile(filePath)
 		if err != nil {
 			fn.PrintError(err)

--- a/cmd/status/status.go
+++ b/cmd/status/status.go
@@ -56,8 +56,9 @@ var Cmd = &cobra.Command{
 		}
 
 		e, err := apic.EnsureEnv()
+		selectedEnv := ""
 		if err == nil {
-			fn.Log(fmt.Sprint(text.Bold(text.Blue("Environment: ")), e.Name))
+			selectedEnv = e.Name
 		} else if errors.Is(err, fileclient.NoEnvSelected) {
 			filePath := fn.ParseKlFile(cmd)
 			klFile, err := fc.GetKlFile(filePath)
@@ -65,10 +66,33 @@ var Cmd = &cobra.Command{
 				fn.PrintError(err)
 				return
 			}
-			fn.Log(fmt.Sprint(text.Bold(text.Blue("Environment: ")), klFile.DefaultEnv))
+			selectedEnv = klFile.DefaultEnv
 		}
-		fn.Log()
-		fn.Log(text.Bold("Cluster Status"))
+		ev, err := apic.GetEnvironment(data.SelectedTeam, selectedEnv)
+		if err == nil {
+			r := text.Yellow("not ready")
+			if ev.Status.IsReady {
+				r = text.Green("ready")
+			}
+			fn.Log(text.Bold(text.Blue("Environment: ")), selectedEnv, fmt.Sprintf("(%s)", r))
+		} else {
+			fn.Log(text.Bold(text.Blue("Environment: ")), selectedEnv)
+		}
+
+		if envclient.InsideBox() {
+			fn.Log(text.Bold("\nWorkspace Status"))
+			env, _ := fc.CurrentEnv()
+			fn.Log("Current Environment: ", text.Blue(env.Name))
+
+			if connect.ChekcWireguardConnection() {
+				fn.Log("Edge Connection:", text.Green("online"))
+			} else {
+				fn.Log("Edge Connection:", text.Yellow("offline"))
+			}
+			return
+		}
+
+		fn.Log(text.Bold("\nCluster Status"))
 
 		config, err := fc.GetClusterConfig(data.SelectedTeam)
 		if err == nil {
@@ -104,18 +128,6 @@ var Cmd = &cobra.Command{
 				fn.Log(text.Yellow("cluster not found"))
 			} else {
 				fn.PrintError(err)
-			}
-		}
-
-		if envclient.InsideBox() {
-			fn.Log(text.Bold("\nWorkspace Status"))
-			env, _ := fc.CurrentEnv()
-			fn.Log("Current Environment: ", text.Blue(env.Name))
-
-			if connect.ChekcWireguardConnection() {
-				fn.Log("Edge Connection:", text.Green("online"))
-			} else {
-				fn.Log("Edge Connection:", text.Yellow("offline"))
 			}
 		}
 	},

--- a/cmd/status/status.go
+++ b/cmd/status/status.go
@@ -70,12 +70,26 @@ var Cmd = &cobra.Command{
 		}
 		ev, err := apic.GetEnvironment(data.SelectedTeam, selectedEnv)
 		if err == nil {
-			r := text.Yellow("not ready")
-			if ev.Status.IsReady {
-				r = text.Green("ready")
+			r := text.Yellow("offline")
+			if ev.ClusterName != "" {
+				if ev.IsArchived {
+					r = text.Yellow("archived")
+				} else {
+					cluster, err := apic.GetCluster(data.SelectedTeam, ev.ClusterName)
+					if err != nil {
+						fn.PrintError(err)
+						return
+					}
+					if time.Since(cluster.LastOnlineAt) < time.Minute {
+						r = text.Green("online")
+					}
+					if ev.Spec.Suspend {
+						r = text.Yellow("suspended")
+					}
+				}
+				fn.Log(text.Bold(text.Blue("Environment: ")), selectedEnv, fmt.Sprintf("(%s)", r))
 			}
-			fn.Log(text.Bold(text.Blue("Environment: ")), selectedEnv, fmt.Sprintf("(%s)", r))
-		} else {
+		} else if selectedEnv != "" {
 			fn.Log(text.Bold(text.Blue("Environment: ")), selectedEnv)
 		}
 

--- a/domain/apiclient/impl.go
+++ b/domain/apiclient/impl.go
@@ -35,12 +35,14 @@ type ApiClient interface {
 	GetEnvironment(teamName, envName string) (*Env, error)
 	EnsureEnv() (*fileclient.Env, error)
 	CloneEnv(teamName, envName, newEnvName, clusterName string) (*Env, error)
+	UpdateEnvironment(teamName string, env *Env, isSuspend bool) error
 	CheckEnvName(teamName, envName string) (bool, error)
 	GetLoadMaps() (map[string]string, MountMap, error)
 
 	//ListBYOKClusters(teamName string) ([]BYOKCluster, error)
 	GetClustersOfTeam(team string) ([]Cluster, error)
 	DeleteCluster(team, clusterName string) error
+	GetCluster(team, clusterName string) (*Cluster, error)
 	ListMreses(teamName string, envName string) ([]Mres, error)
 	ListMresKeys(teamName, envName, importedManagedResource string) ([]string, error)
 	GetMresConfigValues(teamName string) (map[string]string, error)

--- a/domain/apiclient/k3s-local.go
+++ b/domain/apiclient/k3s-local.go
@@ -240,3 +240,24 @@ func (apic *apiClient) DeleteCluster(team, clusterName string) error {
 	}
 	return nil
 }
+
+func (apic *apiClient) GetCluster(team, clusterName string) (*Cluster, error) {
+	cookie, err := getCookie(fn.MakeOption("teamName", team))
+	if err != nil {
+		return nil, fn.NewE(err)
+	}
+	respData, err := klFetch("cli_getBYOKCluster", map[string]any{
+		"name": clusterName,
+	}, &cookie)
+
+	if err != nil {
+		return nil, fn.NewE(err)
+	}
+
+	fromResp, err := GetFromResp[Cluster](respData)
+	if err != nil {
+		return nil, fn.NewE(err)
+	}
+	return fromResp, nil
+
+}

--- a/klbox-docker/Dockerfile
+++ b/klbox-docker/Dockerfile
@@ -33,7 +33,7 @@ RUN groupadd -g 1000 kl && useradd -u 1000 -g 1000 -m kl && usermod -aG sudo kl 
 RUN sed -i 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' /etc/pam.d/sshd
 
 RUN echo "GatewayPorts yes" >> /etc/ssh/sshd_config
-
+RUN echo "AuthorizedKeysFile  .ssh/authorized_keys .ssh/id_rsa.pub" >> /etc/ssh/sshd_config
 
 ENV HOSTNAME box
 RUN mkdir -m 0755 /nix && chown kl /nix

--- a/klbox-docker/entrypoint.sh
+++ b/klbox-docker/entrypoint.sh
@@ -3,9 +3,15 @@
 set -o errexit
 set -o pipefail
 
-/docker-socket.sh &
-
 /start.sh
 
 export SSH_PORT=$SSH_PORT
-/usr/sbin/sshd -D -p "$SSH_PORT"
+
+/usr/sbin/sshd -D -p "$SSH_PORT" &
+pid=$!
+
+cat >/kl-tmp/kill-sshd.sh <<EOF
+sudo kill -9 $pid
+EOF
+
+wait $pid


### PR DESCRIPTION
## Summary by Sourcery

Remove dependency on Docker socket by refactoring container management logic and introduce new commands to suspend and resume environments. Enhance environment status reporting with detailed states.

New Features:
- Introduce 'pause' and 'resume' commands to suspend and resume environments, respectively.

Enhancements:
- Refactor the environment status display to include more detailed information such as 'archived', 'suspended', and 'online' statuses.
- Modify the container restart logic to remove dependency on Docker socket by using a script to manage SSHD processes.
- Update the environment management API to support suspending and resuming environments.