### PR TITLE
Feature/issue 216

### DIFF
--- a/clis/kl/loadsubs.go
+++ b/clis/kl/loadsubs.go
@@ -41,6 +41,7 @@ func init() {
 	rootCmd.AddCommand(clone.Cmd)
 	rootCmd.AddCommand(env.Cmd)
 	rootCmd.AddCommand(runner.InitCommand)
+	rootCmd.AddCommand(runner.AttachCommand)
 	rootCmd.AddCommand(set_base_url.Cmd)
 
 	rootCmd.AddCommand(intercept.Cmd)

--- a/cmd/auth/auth.go
+++ b/cmd/auth/auth.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"github.com/kloudlite/kl/domain/fileclient"
 	"github.com/spf13/cobra"
 )
 
@@ -11,6 +12,8 @@ var Cmd = &cobra.Command{
 }
 
 func init() {
+	fileclient.OnlyOutsideBox(loginCmd)
+	fileclient.OnlyOutsideBox(logoutCmd)
 	Cmd.AddCommand(loginCmd)
 	Cmd.AddCommand(logoutCmd)
 	Cmd.AddCommand(authStatusCmd)

--- a/cmd/auth/logout.go
+++ b/cmd/auth/logout.go
@@ -24,12 +24,11 @@ var logoutCmd = &cobra.Command{
 			fn.PrintError(err)
 			return
 		}
-		err = stopAllContainers(cmd)
-		if err != nil {
-			fn.PrintError(err)
-			return
-		}
-
+		// err = stopAllContainers(cmd)
+		// if err != nil {
+		// 	fn.PrintError(err)
+		// 	return
+		// }
 		if err := fc.Logout(); err != nil {
 			fn.PrintError(err)
 			return

--- a/cmd/box/boxpkg/main.go
+++ b/cmd/box/boxpkg/main.go
@@ -5,9 +5,10 @@ import (
 	"crypto/md5"
 	"errors"
 	"fmt"
-	"github.com/kloudlite/kl/k3s"
 	"io"
 	"os"
+
+	"github.com/kloudlite/kl/k3s"
 
 	"github.com/kloudlite/kl/domain/apiclient"
 	"github.com/kloudlite/kl/domain/fileclient"
@@ -91,14 +92,17 @@ func NewClient(cmd *cobra.Command, args []string) (BoxClient, error) {
 
 	env, err := fc.EnvOfPath(cwd)
 	if err != nil && errors.Is(err, fileclient.NoEnvSelected) {
-		environment, err := apic.GetEnvironment(klFile.TeamName, klFile.DefaultEnv)
-		if err != nil {
-			return nil, fn.NewE(err)
-		}
-		env = &fileclient.Env{
-			Name:    environment.Metadata.Name,
+		env := &fileclient.Env{
 			SSHPort: 0,
 		}
+		if klFile.DefaultEnv != "" && klFile.TeamName != "" {
+			environment, err := apic.GetEnvironment(klFile.TeamName, klFile.DefaultEnv)
+			if err != nil {
+				return nil, fn.NewE(err)
+			}
+			env.Name = environment.Metadata.Name
+		}
+
 		data, err := fileclient.GetExtraData()
 		if err != nil {
 			return nil, fn.NewE(err)
@@ -113,8 +117,6 @@ func NewClient(cmd *cobra.Command, args []string) (BoxClient, error) {
 		if err := fileclient.SaveExtraData(data); err != nil {
 			return nil, fn.NewE(err)
 		}
-	} else if err != nil {
-		return nil, fn.NewE(err)
 	}
 
 	return &client{

--- a/cmd/box/boxpkg/start.go
+++ b/cmd/box/boxpkg/start.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/kloudlite/kl/cmd/cluster"
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/kloudlite/kl/cmd/cluster"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/filters"
@@ -93,9 +94,11 @@ func (c *client) Start() error {
 
 	}
 
-	_, err = c.apic.GetAccVPNConfig(c.klfile.TeamName)
-	if err != nil {
-		return err
+	if c.klfile.TeamName != "" {
+		_, err = c.apic.GetAccVPNConfig(c.klfile.TeamName)
+		if err != nil {
+			return err
+		}
 	}
 
 	_, err = c.startContainer(boxHash.KLConfHash)

--- a/cmd/list/env.go
+++ b/cmd/list/env.go
@@ -41,6 +41,9 @@ func listEnvironments(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return functions.NewE(err)
 	}
+	if currentTeam == "" {
+		return fn.Errorf("[#] no team selected")
+	}
 	envs, err := apic.ListEnvs(currentTeam)
 	if err != nil {
 		return functions.NewE(err)

--- a/cmd/runner/attach.go
+++ b/cmd/runner/attach.go
@@ -1,0 +1,169 @@
+package runner
+
+import (
+	"errors"
+	"fmt"
+	confighandler "github.com/kloudlite/kl/pkg/config-handler"
+	"os"
+
+	"github.com/kloudlite/kl/cmd/box/boxpkg"
+	"github.com/kloudlite/kl/cmd/box/boxpkg/hashctrl"
+	"github.com/kloudlite/kl/domain/apiclient"
+	"github.com/kloudlite/kl/domain/envclient"
+	"github.com/kloudlite/kl/domain/fileclient"
+	fn "github.com/kloudlite/kl/pkg/functions"
+
+	"github.com/kloudlite/kl/pkg/ui/fzf"
+	"github.com/kloudlite/kl/pkg/ui/text"
+
+	"github.com/spf13/cobra"
+)
+
+var AttachCommand = &cobra.Command{
+	Use:   "attach",
+	Short: "attach team and environment to the kl-config file",
+	Long:  `use this command to attach team and environment to the kl-config file`,
+	Run: func(cmd *cobra.Command, args []string) {
+
+		fc, err := fileclient.New()
+		if err != nil {
+			fn.PrintError(err)
+			return
+		}
+		apic, err := apiclient.New()
+		if err != nil {
+			fn.PrintError(err)
+			return
+		}
+
+		//if envclient.InsideBox() {
+		//	fn.PrintError(fn.Error("cannot re-initialize workspace in dev box"))
+		//	return
+		//}
+
+		//if _, err = fc.GetKlFile(""); err == nil {
+		//	fn.Printf(text.Yellow("workspace is already initilized. Do you want to override? [y/N]: "))
+		//	if !fn.Confirm("Y", "N") {
+		//		return
+		//	}
+		//} else if !errors.Is(err, confighandler.ErrKlFileNotExists) {
+		//	fn.PrintError(err)
+		//	return
+		//}
+
+		filepath := ""
+		if envclient.InsideBox() {
+			filepath = "/home/kl/workspace/kl.yml"
+		}
+		klFile, err := fc.GetKlFile(filepath)
+		if err != nil && errors.Is(err, confighandler.ErrKlFileNotExists) {
+			klFile = &fileclient.KLFileType{
+				Version: "v1",
+			}
+		}
+		if err != nil && !errors.Is(err, confighandler.ErrKlFileNotExists) {
+			fn.PrintError(err)
+			return
+		}
+
+		selectedTeam, err := selectTeam(apic)
+		if err != nil {
+			fn.PrintError(err)
+			return
+		} else {
+			if selectedEnv, err := selectEnv(apic, fc, *selectedTeam); err != nil {
+				fn.PrintError(err)
+			} else {
+				//newKlFile := fileclient.KLFileType{
+				//	TeamName:   *selectedTeam,
+				//	DefaultEnv: *selectedEnv,
+				//	Version:    "v1",
+				//	Packages:   []string{"neovim", "git"},
+				//}
+				klFile.TeamName = *selectedTeam
+				klFile.DefaultEnv = *selectedEnv
+				if err := fc.WriteKLFile(*klFile); err != nil {
+					fn.PrintError(err)
+				} else {
+					fn.Printf(text.Green("team name and environment updated.\n"))
+				}
+			}
+		}
+
+		dir, err := os.Getwd()
+		if err != nil {
+			fn.PrintError(err)
+			return
+		}
+
+		if err := hashctrl.SyncBoxHash(apic, fc, dir); err != nil {
+			fn.PrintError(err)
+			return
+		}
+
+		c, err := boxpkg.NewClient(cmd, args)
+		if err != nil {
+			fn.PrintError(err)
+			return
+		}
+
+		if err := c.ConfirmBoxRestart(); err != nil {
+			fn.PrintError(err)
+			return
+		}
+
+	},
+}
+
+func selectTeam(apic apiclient.ApiClient) (*string, error) {
+	if teams, err := apic.ListTeams(); err == nil {
+		if selectedTeam, err := fzf.FindOne(
+			teams,
+			func(team apiclient.Team) string {
+				return team.Metadata.Name + " #" + team.Metadata.Name
+			},
+			fzf.WithPrompt("select kloudlite team > "),
+		); err != nil {
+			return nil, fn.NewE(err)
+		} else {
+			return &selectedTeam.Metadata.Name, nil
+		}
+	} else {
+		return nil, fn.NewE(err)
+	}
+}
+
+func selectEnv(apic apiclient.ApiClient, fc fileclient.FileClient, teamName string) (*string, error) {
+	if envs, err := apic.ListEnvs(teamName); err == nil {
+		if selectedEnv, err := fzf.FindOne(
+			envs,
+			func(env apiclient.Env) string {
+				if env.ClusterName == "" {
+					return fmt.Sprintf("%s (%s) template-env", env.DisplayName, env.Metadata.Name)
+				}
+				return fmt.Sprintf("%s (%s) compute-env", env.DisplayName, env.Metadata.Name)
+			},
+			fzf.WithPrompt("select environment > "),
+		); err != nil {
+			return nil, fn.NewE(err)
+		} else {
+			cwd, err := os.Getwd()
+			if envclient.InsideBox() {
+				cwd = os.Getenv("KL_WORKSPACE")
+			}
+			env := &fileclient.Env{
+				Name: selectedEnv.Metadata.Name,
+			}
+			err = fc.SelectEnvOnPath(cwd, *env)
+			if err != nil {
+				return nil, fn.NewE(err)
+			}
+			if err != nil {
+				return nil, fn.NewE(err)
+			}
+			return &selectedEnv.Metadata.Name, nil
+		}
+	} else {
+		return nil, fn.NewE(err)
+	}
+}

--- a/cmd/runner/init.go
+++ b/cmd/runner/init.go
@@ -30,11 +30,6 @@ var InitCommand = &cobra.Command{
 			fn.PrintError(err)
 			return
 		}
-		apic, err := apiclient.New()
-		if err != nil {
-			fn.PrintError(err)
-			return
-		}
 
 		if envclient.InsideBox() {
 			fn.PrintError(fn.Error("cannot re-initialize workspace in dev box"))
@@ -51,27 +46,27 @@ var InitCommand = &cobra.Command{
 			return
 		}
 
-		selectedTeam, err := selectTeam(apic)
-		if err != nil {
-			fn.PrintError(err)
-			return
-		} else {
-			if selectedEnv, err := selectEnv(apic, fc, *selectedTeam); err != nil {
-				fn.PrintError(err)
-			} else {
-				newKlFile := fileclient.KLFileType{
-					TeamName:   *selectedTeam,
-					DefaultEnv: *selectedEnv,
-					Version:    "v1",
-					Packages:   []string{"neovim", "git"},
-				}
-				if err := fc.WriteKLFile(newKlFile); err != nil {
-					fn.PrintError(err)
-				} else {
-					fn.Printf(text.Green("workspace initialized successfully.\n"))
-				}
-			}
+		// // selectedTeam, err := selectTeam(apic)
+		// if err != nil {
+		// 	fn.PrintError(err)
+		// 	return
+		// } else {
+		// if selectedEnv, err := selectEnv(apic, fc, *selectedTeam); err != nil {
+		// 	fn.PrintError(err)
+		// } else {
+		newKlFile := fileclient.KLFileType{
+			// TeamName:   *selectedTeam,
+			// DefaultEnv: *selectedEnv,
+			Version:  "v1",
+			Packages: []string{"neovim", "git"},
 		}
+		if err := fc.WriteKLFile(newKlFile); err != nil {
+			fn.PrintError(err)
+		} else {
+			fn.Printf(text.Green("workspace initialized successfully.\n"))
+		}
+		// }
+		// }
 
 		dir, err := os.Getwd()
 		if err != nil {
@@ -79,6 +74,11 @@ var InitCommand = &cobra.Command{
 			return
 		}
 
+		apic, err := apiclient.New()
+		if err != nil {
+			fn.PrintError(err)
+			return
+		}
 		if err := hashctrl.SyncBoxHash(apic, fc, dir); err != nil {
 			fn.PrintError(err)
 			return

--- a/cmd/runner/init.go
+++ b/cmd/runner/init.go
@@ -2,7 +2,6 @@ package runner
 
 import (
 	"errors"
-	"fmt"
 	"os"
 
 	"github.com/kloudlite/kl/cmd/box/boxpkg"
@@ -13,7 +12,6 @@ import (
 	confighandler "github.com/kloudlite/kl/pkg/config-handler"
 	fn "github.com/kloudlite/kl/pkg/functions"
 
-	"github.com/kloudlite/kl/pkg/ui/fzf"
 	"github.com/kloudlite/kl/pkg/ui/text"
 
 	"github.com/spf13/cobra"
@@ -98,55 +96,55 @@ var InitCommand = &cobra.Command{
 	},
 }
 
-func selectTeam(apic apiclient.ApiClient) (*string, error) {
-	if teams, err := apic.ListTeams(); err == nil {
-		if selectedTeam, err := fzf.FindOne(
-			teams,
-			func(team apiclient.Team) string {
-				return team.Metadata.Name + " #" + team.Metadata.Name
-			},
-			fzf.WithPrompt("select kloudlite team > "),
-		); err != nil {
-			return nil, fn.NewE(err)
-		} else {
-			return &selectedTeam.Metadata.Name, nil
-		}
-	} else {
-		return nil, fn.NewE(err)
-	}
-}
-
-func selectEnv(apic apiclient.ApiClient, fc fileclient.FileClient, teamName string) (*string, error) {
-	if envs, err := apic.ListEnvs(teamName); err == nil {
-		if selectedEnv, err := fzf.FindOne(
-			envs,
-			func(env apiclient.Env) string {
-				if env.ClusterName == "" {
-					return fmt.Sprintf("%s (%s) template-env", env.DisplayName, env.Metadata.Name)
-				}
-				return fmt.Sprintf("%s (%s) compute-env", env.DisplayName, env.Metadata.Name)
-			},
-			fzf.WithPrompt("select environment > "),
-		); err != nil {
-			return nil, fn.NewE(err)
-		} else {
-			cwd, err := os.Getwd()
-			env := &fileclient.Env{
-				Name: selectedEnv.Metadata.Name,
-			}
-			err = fc.SelectEnvOnPath(cwd, *env)
-			if err != nil {
-				return nil, fn.NewE(err)
-			}
-			if err != nil {
-				return nil, fn.NewE(err)
-			}
-			return &selectedEnv.Metadata.Name, nil
-		}
-	} else {
-		return nil, fn.NewE(err)
-	}
-}
+//func selectTeam(apic apiclient.ApiClient) (*string, error) {
+//	if teams, err := apic.ListTeams(); err == nil {
+//		if selectedTeam, err := fzf.FindOne(
+//			teams,
+//			func(team apiclient.Team) string {
+//				return team.Metadata.Name + " #" + team.Metadata.Name
+//			},
+//			fzf.WithPrompt("select kloudlite team > "),
+//		); err != nil {
+//			return nil, fn.NewE(err)
+//		} else {
+//			return &selectedTeam.Metadata.Name, nil
+//		}
+//	} else {
+//		return nil, fn.NewE(err)
+//	}
+//}
+//
+//func selectEnv(apic apiclient.ApiClient, fc fileclient.FileClient, teamName string) (*string, error) {
+//	if envs, err := apic.ListEnvs(teamName); err == nil {
+//		if selectedEnv, err := fzf.FindOne(
+//			envs,
+//			func(env apiclient.Env) string {
+//				if env.ClusterName == "" {
+//					return fmt.Sprintf("%s (%s) template-env", env.DisplayName, env.Metadata.Name)
+//				}
+//				return fmt.Sprintf("%s (%s) compute-env", env.DisplayName, env.Metadata.Name)
+//			},
+//			fzf.WithPrompt("select environment > "),
+//		); err != nil {
+//			return nil, fn.NewE(err)
+//		} else {
+//			cwd, err := os.Getwd()
+//			env := &fileclient.Env{
+//				Name: selectedEnv.Metadata.Name,
+//			}
+//			err = fc.SelectEnvOnPath(cwd, *env)
+//			if err != nil {
+//				return nil, fn.NewE(err)
+//			}
+//			if err != nil {
+//				return nil, fn.NewE(err)
+//			}
+//			return &selectedEnv.Metadata.Name, nil
+//		}
+//	} else {
+//		return nil, fn.NewE(err)
+//	}
+//}
 
 func init() {
 	InitCommand.Flags().StringP("team", "a", "", "team name")

--- a/domain/apiclient/environment.go
+++ b/domain/apiclient/environment.go
@@ -27,6 +27,8 @@ const (
 	EnvironmentType      = "environment"
 )
 
+var NoDefaultEnvError = fn.Error("please initialize kl.yml by running `kl init` in current workspace")
+
 // func GetEnvironment(envName string) (*Env, error) {
 // 	var err error
 // 	projectName, err := EnsureProject()
@@ -117,7 +119,7 @@ func (apic *apiClient) EnsureEnv() (*fileclient.Env, error) {
 		return nil, functions.NewE(err)
 	}
 	if kt.DefaultEnv == "" {
-		return nil, functions.Error("please initialize kl.yml by running `kl init` in current workspace")
+		return nil, NoDefaultEnvError
 	}
 	e, err := apic.GetEnvironment(kt.TeamName, kt.DefaultEnv)
 	if err != nil {

--- a/domain/fileclient/context.go
+++ b/domain/fileclient/context.go
@@ -51,7 +51,7 @@ type WGConfig struct {
 }
 
 type Env struct {
-	Name    string `json:"name"`
+	Name    string `json:"name,omitempty"`
 	SSHPort int    `json:"sshPort"`
 }
 

--- a/domain/fileclient/kl-file.go
+++ b/domain/fileclient/kl-file.go
@@ -11,7 +11,8 @@ import (
 
 type KLFileType struct {
 	Version    string   `json:"version" yaml:"version"`
-	DefaultEnv string   `json:"defaultEnv" yaml:"defaultEnv"`
+	DefaultEnv string   `json:"defaultEnv,omitempty" yaml:"defaultEnv,omitempty"`
+	TeamName   string   `json:"teamName,omitempty" yaml:"teamName,omitempty"`
 	Packages   []string `json:"packages" yaml:"packages"`
 
 	EnvVars EnvVars `json:"envVars" yaml:"envVars"`
@@ -19,7 +20,6 @@ type KLFileType struct {
 	Ports   []int   `json:"ports" yaml:"ports"`
 
 	// InitScripts []string `json:"initScripts" yaml:"initScripts"`
-	TeamName string `json:"teamName" yaml:"teamName"`
 }
 
 const (
@@ -57,12 +57,12 @@ func (c *fclient) GetKlFile(filePath string) (*KLFileType, error) {
 	if err != nil {
 		return nil, functions.NewE(err)
 	}
-	if klfile.TeamName == "" {
-		return nil, functions.Error("kl file is not valid, teamName is not set properly. You can re-initialize kl file by running \"kl init\" command.")
-	}
-	if klfile.DefaultEnv == "" {
-		return nil, functions.Error("kl file is not valid, defaultEnv is not set properly. You can re-intialize kl file by running \"kl init\" command.")
-	}
+	// if klfile.TeamName == "" {
+	// 	return nil, functions.Error("kl file is not valid, teamName is not set properly. You can re-initialize kl file by running \"kl init\" command.")
+	// }
+	// if klfile.DefaultEnv == "" {
+	// 	return nil, functions.Error("kl file is not valid, defaultEnv is not set properly. You can re-intialize kl file by running \"kl init\" command.")
+	// }
 	return klfile, nil
 }
 

--- a/klbox-docker/.zshrc
+++ b/klbox-docker/.zshrc
@@ -38,6 +38,9 @@ if [[ -f $ZSH_HIGHLIGHT_PATH ]]; then
 fi
 
 function update_rprompt {
+ if [ -z "$KL_TEAM_NAME" ]; then
+  return
+ fi
  [ -f /kl-tmp/online.status ] || return
  online_status=$(tail -n 1 /kl-tmp/online.status)
  if [ "$online_status" = "online" ]; then

--- a/klbox-docker/start.sh
+++ b/klbox-docker/start.sh
@@ -26,8 +26,6 @@ EOL
 chown -R kl /kl-tmp/global-profile
 
 mkdir -p /etc/wireguard
-echo $KL_TEAM_NAME
-set -x
 
 if [[ -n "${CLUSTER_GATEWAY_IP}" && -n "${CLUSTER_IP_RANGE}" ]]; then
   CLUSTER_IP_RANGE=$(echo $CLUSTER_IP_RANGE | sed 's/\//###/g')
@@ -44,11 +42,12 @@ if [[ -n "${CLUSTER_GATEWAY_IP}" && -n "${CLUSTER_IP_RANGE}" ]]; then
   sudo wg-quick up kl-workspace-wg
 fi
 
-cat /.cache/kl/vpn/${KL_TEAM_NAME}.json | jq -r .wg | base64 -d >/tmp/kl-vpn.conf
-sudo cp /tmp/kl-vpn.conf /etc/wireguard/kl-vpn.conf
-rm /tmp/kl-vpn.conf
-sudo wg-quick up kl-vpn
-set +x
+if [[ -n "${KL_TEAM_NAME}" ]]; then
+  cat /.cache/kl/vpn/${KL_TEAM_NAME}.json | jq -r .wg | base64 -d >/tmp/kl-vpn.conf
+  sudo cp /tmp/kl-vpn.conf /etc/wireguard/kl-vpn.conf
+  rm /tmp/kl-vpn.conf
+  sudo wg-quick up kl-vpn
+fi
 
 entrypoint_executed="/home/kl/.kloudlite_entrypoint_executed"
 if [ ! -f "$entrypoint_executed" ]; then

--- a/klbox-docker/start.sh
+++ b/klbox-docker/start.sh
@@ -30,18 +30,18 @@ echo $KL_TEAM_NAME
 set -x
 
 if [[ -n "${CLUSTER_GATEWAY_IP}" && -n "${CLUSTER_IP_RANGE}" ]]; then
-  CLUSTER_IP_RANGE=$(echo $CLUSTER_IP_RANGE | sed 's/\//###/g')
+    CLUSTER_IP_RANGE=$(echo $CLUSTER_IP_RANGE | sed 's/\//###/g')
 
-  cat /.cache/kl/kl-workspace-wg.conf |
-    sed "s/#CLUSTER_GATEWAY_IP/${CLUSTER_GATEWAY_IP:-null}/" |
-    sed "s/#CLUSTER_IP_RANGE/${CLUSTER_IP_RANGE:-null}/" >/tmp/wg-cong
+    cat /.cache/kl/kl-workspace-wg.conf | \
+        sed "s/#CLUSTER_GATEWAY_IP/${CLUSTER_GATEWAY_IP:-null}/" | \
+        sed "s/#CLUSTER_IP_RANGE/${CLUSTER_IP_RANGE:-null}/" >/tmp/wg-cong
 
-  sed -i "s/###/\//" /tmp/wg-cong
+    sed -i "s/###/\//" /tmp/wg-cong
 
-  sudo cp /tmp/wg-cong /etc/wireguard/kl-workspace-wg.conf
-  rm /tmp/wg-cong
+    sudo cp /tmp/wg-cong /etc/wireguard/kl-workspace-wg.conf
+    rm /tmp/wg-cong
 
-  sudo wg-quick up kl-workspace-wg
+    sudo wg-quick up kl-workspace-wg
 fi
 
 cat /.cache/kl/vpn/${KL_TEAM_NAME}.json | jq -r .wg | base64 -d >/tmp/kl-vpn.conf
@@ -96,9 +96,10 @@ if [ $npkgs -gt 0 ]; then
   npath=$(nix shell $(cat $KL_HASH_FILE | jq '.config.packageHashes | to_entries | map_values(. = .value) | .[]' -r | xargs -I{} printf "%s " {}) --command printenv PATH)
   echo export PATH=$PATH:$npath >> /kl-tmp/env
 
-  rm -rf /kl-tmp/nix-ld-path /kl-tmp/nix-include
   cat > /kl-tmp/nix-ld-library-and-cpath.sh <<'EOS'
     dir=$(nix eval "$1" --raw)
+
+    rm -rf /kl-tmp/nix-ld-path /kl-tmp/nix-include
 
     if [ -d "$dir/lib" ]; then
       echo -n "$dir/lib:" >> /kl-tmp/nix-ld-path

--- a/klbox-docker/start.sh
+++ b/klbox-docker/start.sh
@@ -30,18 +30,18 @@ echo $KL_TEAM_NAME
 set -x
 
 if [[ -n "${CLUSTER_GATEWAY_IP}" && -n "${CLUSTER_IP_RANGE}" ]]; then
-    CLUSTER_IP_RANGE=$(echo $CLUSTER_IP_RANGE | sed 's/\//###/g')
+  CLUSTER_IP_RANGE=$(echo $CLUSTER_IP_RANGE | sed 's/\//###/g')
 
-    cat /.cache/kl/kl-workspace-wg.conf | \
-        sed "s/#CLUSTER_GATEWAY_IP/${CLUSTER_GATEWAY_IP:-null}/" | \
-        sed "s/#CLUSTER_IP_RANGE/${CLUSTER_IP_RANGE:-null}/" >/tmp/wg-cong
+  cat /.cache/kl/kl-workspace-wg.conf |
+    sed "s/#CLUSTER_GATEWAY_IP/${CLUSTER_GATEWAY_IP:-null}/" |
+    sed "s/#CLUSTER_IP_RANGE/${CLUSTER_IP_RANGE:-null}/" >/tmp/wg-cong
 
-    sed -i "s/###/\//" /tmp/wg-cong
+  sed -i "s/###/\//" /tmp/wg-cong
 
-    sudo cp /tmp/wg-cong /etc/wireguard/kl-workspace-wg.conf
-    rm /tmp/wg-cong
+  sudo cp /tmp/wg-cong /etc/wireguard/kl-workspace-wg.conf
+  rm /tmp/wg-cong
 
-    sudo wg-quick up kl-workspace-wg
+  sudo wg-quick up kl-workspace-wg
 fi
 
 cat /.cache/kl/vpn/${KL_TEAM_NAME}.json | jq -r .wg | base64 -d >/tmp/kl-vpn.conf
@@ -96,10 +96,9 @@ if [ $npkgs -gt 0 ]; then
   npath=$(nix shell $(cat $KL_HASH_FILE | jq '.config.packageHashes | to_entries | map_values(. = .value) | .[]' -r | xargs -I{} printf "%s " {}) --command printenv PATH)
   echo export PATH=$PATH:$npath >> /kl-tmp/env
 
+  rm -rf /kl-tmp/nix-ld-path /kl-tmp/nix-include
   cat > /kl-tmp/nix-ld-library-and-cpath.sh <<'EOS'
     dir=$(nix eval "$1" --raw)
-
-    rm -rf /kl-tmp/nix-ld-path /kl-tmp/nix-include
 
     if [ -d "$dir/lib" ]; then
       echo -n "$dir/lib:" >> /kl-tmp/nix-ld-path


### PR DESCRIPTION
## Summary by Sourcery

Add a new 'attach' command to the runner package for attaching team and environment to the kl-config file. Refactor the initialization process to streamline KLFileType creation and update the VPN setup in start.sh to be conditional on KL_TEAM_NAME.

New Features:
- Introduce a new 'attach' command to the runner package, allowing users to attach a team and environment to the kl-config file.

Enhancements:
- Refactor the initialization process to simplify the creation of the KLFileType object without requiring team and environment selection upfront.
- Modify the VPN configuration setup in the start.sh script to conditionally execute based on the presence of KL_TEAM_NAME.