### PR TITLE
issues fixed with workspace switching and stopping containers

### DIFF
--- a/cmd/box/boxpkg/start.go
+++ b/cmd/box/boxpkg/start.go
@@ -87,12 +87,12 @@ func (c *client) Start() error {
 			return functions.NewE(err)
 		}
 
-		if c.klfile.TeamName != "" {
-			_, err = c.apic.GetClusterConfig(c.klfile.TeamName)
-			if err != nil {
-				return err
-			}
-		}
+		//if c.klfile.TeamName != "" {
+		//	_, err = c.apic.GetClusterConfig(c.klfile.TeamName)
+		//	if err != nil {
+		//		return err
+		//	}
+		//}
 
 	}
 

--- a/cmd/box/boxpkg/start.go
+++ b/cmd/box/boxpkg/start.go
@@ -87,9 +87,11 @@ func (c *client) Start() error {
 			return functions.NewE(err)
 		}
 
-		_, err = c.apic.GetClusterConfig(c.klfile.TeamName)
-		if err != nil {
-			return err
+		if c.klfile.TeamName != "" {
+			_, err = c.apic.GetClusterConfig(c.klfile.TeamName)
+			if err != nil {
+				return err
+			}
 		}
 
 	}

--- a/cmd/box/boxpkg/utils.go
+++ b/cmd/box/boxpkg/utils.go
@@ -376,9 +376,9 @@ func (c *client) stopContainer(path string) error {
 	}
 
 	for _, c2 := range existingContainers {
-		if c2.Labels["kl-team"] == c.klfile.TeamName {
-			continue
-		}
+		//if c2.Labels["kl-team"] == c.klfile.TeamName {
+		//	continue
+		//}
 		timeOut := 0
 		if err := c.cli.ContainerStop(context.Background(), c2.ID, container.StopOptions{
 			Timeout: &timeOut,

--- a/cmd/box/boxpkg/utils.go
+++ b/cmd/box/boxpkg/utils.go
@@ -376,9 +376,6 @@ func (c *client) stopContainer(path string) error {
 	}
 
 	for _, c2 := range existingContainers {
-		//if c2.Labels["kl-team"] == c.klfile.TeamName {
-		//	continue
-		//}
 		timeOut := 0
 		if err := c.cli.ContainerStop(context.Background(), c2.ID, container.StopOptions{
 			Timeout: &timeOut,

--- a/cmd/cluster/clean.go
+++ b/cmd/cluster/clean.go
@@ -15,7 +15,7 @@ var cleanCmd = &cobra.Command{
 	Short: "clean the cluster",
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := cleanCluster(cmd); err != nil {
-			fmt.Println(err)
+			fn.PrintError(err)
 			return
 		}
 	},


### PR DESCRIPTION
## Summary by Sourcery

Fix issues related to workspace switching and stopping containers by adding a check for team name before fetching cluster configuration and removing incorrect label checks when stopping containers. Enhance error handling in the cluster cleaning command.

Bug Fixes:
- Fix the issue where the application attempted to get cluster configuration even when the team name was not specified.
- Resolve the problem of containers not stopping due to incorrect label checks.

Enhancements:
- Improve error handling in the cluster cleaning command by using a consistent error printing function.