### PR TITLE
:sparkles: Added kubectl and k9s support for debug

### DIFF
--- a/clis/kl/loadsubs.go
+++ b/clis/kl/loadsubs.go
@@ -1,6 +1,8 @@
 package kl
 
 import (
+	"os/exec"
+
 	"github.com/kloudlite/kl/cmd/auth"
 	"github.com/kloudlite/kl/cmd/box"
 	"github.com/kloudlite/kl/cmd/clone"
@@ -10,6 +12,7 @@ import (
 	"github.com/kloudlite/kl/cmd/expose"
 	"github.com/kloudlite/kl/cmd/get"
 	"github.com/kloudlite/kl/cmd/intercept"
+	"github.com/kloudlite/kl/cmd/kubectl"
 	"github.com/kloudlite/kl/cmd/list"
 	"github.com/kloudlite/kl/cmd/packages"
 	"github.com/kloudlite/kl/cmd/runner"
@@ -45,7 +48,6 @@ func init() {
 	rootCmd.AddCommand(set_base_url.Cmd)
 
 	rootCmd.AddCommand(intercept.Cmd)
-	//rootCmd.AddCommand(vpn.Cmd)
 
 	rootCmd.AddCommand(cluster.Cmd)
 	rootCmd.AddCommand(expose.Cmd)
@@ -56,4 +58,14 @@ func init() {
 	rootCmd.AddCommand(packages.LibCmd)
 
 	rootCmd.AddCommand(connect.Command)
+
+	if flags.IsDev() {
+		if _, err := exec.LookPath("k9s"); err == nil {
+			rootCmd.AddCommand(kubectl.K9sCmd)
+		}
+
+		if _, err := exec.LookPath("kubectl"); err == nil {
+			rootCmd.AddCommand(kubectl.KubectlCmd)
+		}
+	}
 }

--- a/cmd/kubectl/k9s.go
+++ b/cmd/kubectl/k9s.go
@@ -1,0 +1,65 @@
+package kubectl
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+
+	"github.com/kloudlite/kl/k3s"
+	fn "github.com/kloudlite/kl/pkg/functions"
+	"github.com/spf13/cobra"
+)
+
+var K9sCmd = &cobra.Command{
+	Use:                "k9s",
+	Short:              "k9s is a terminal UI for Kubernetes",
+	DisableFlagParsing: true,
+	Run: func(cmd *cobra.Command, args []string) {
+
+		kconfPath, err := GetPath(cmd)
+		if err != nil {
+			fn.PrintError(err)
+			return
+		}
+
+		c := exec.Command("k9s", args...)
+		c.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kconfPath))
+
+		c.Stdout = os.Stdout
+		c.Stderr = os.Stderr
+
+		if err := c.Run(); err != nil {
+			err = nil
+			return
+		}
+	},
+}
+
+func GetPath(cmd *cobra.Command) ([]byte, error) {
+	kc, err := k3s.NewClient(cmd)
+	if err != nil {
+		return nil, err
+	}
+
+	out, err := kc.Exec("cat /etc/rancher/k3s/k3s.yaml")
+	if err != nil {
+		return nil, err
+	}
+
+	td, err := os.MkdirTemp("", "kl-tmp")
+	if err != nil {
+		return nil, err
+	}
+
+	kconfPath := path.Join(td, "k3s.yaml")
+
+	if err := os.WriteFile(kconfPath, out, 0644); err != nil {
+		return nil, err
+	}
+
+	return []byte(kconfPath), nil
+}
+
+func init() {
+}

--- a/cmd/kubectl/kubectl.go
+++ b/cmd/kubectl/kubectl.go
@@ -1,0 +1,38 @@
+package kubectl
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	fn "github.com/kloudlite/kl/pkg/functions"
+	"github.com/spf13/cobra"
+)
+
+var KubectlCmd = &cobra.Command{
+	Use:                "kubectl",
+	Short:              "kubectl is a command line tool for controlling Kubernetes clusters",
+	DisableFlagParsing: true,
+	Run: func(cmd *cobra.Command, args []string) {
+		kconfPath, err := GetPath(cmd)
+		if err != nil {
+			fn.PrintError(err)
+			return
+		}
+
+		c := exec.Command("kubectl", args...)
+		c.Env = append(os.Environ(), fmt.Sprintf("KUBECONFIG=%s", kconfPath))
+
+		c.Stdout = os.Stdout
+		c.Stderr = os.Stderr
+
+		if err := c.Run(); err != nil {
+			err = nil
+			return
+		}
+
+	},
+}
+
+func init() {
+}

--- a/k3s/main.go
+++ b/k3s/main.go
@@ -18,6 +18,7 @@ type K3sClient interface {
 	CheckK3sRunningLocally() (bool, error)
 	RemoveClusterVolume(clusterName string) error
 	CheckK3sServerRunning() (string, error)
+	Exec(script string) ([]byte, error)
 }
 
 type client struct {


### PR DESCRIPTION
(KL_DEV=true) env can activate debug mode and then cluster can be accessed using kubectl or k9s