### PR TITLE
:bug: Fixed issue with stdin with k9s and kubectl

### DIFF
--- a/cmd/kubectl/k9s.go
+++ b/cmd/kubectl/k9s.go
@@ -28,6 +28,7 @@ var K9sCmd = &cobra.Command{
 
 		c.Stdout = os.Stdout
 		c.Stderr = os.Stderr
+		c.Stdin = os.Stdin
 
 		if err := c.Run(); err != nil {
 			err = nil

--- a/cmd/kubectl/kubectl.go
+++ b/cmd/kubectl/kubectl.go
@@ -25,6 +25,7 @@ var KubectlCmd = &cobra.Command{
 
 		c.Stdout = os.Stdout
 		c.Stderr = os.Stderr
+		c.Stdin = os.Stdin
 
 		if err := c.Run(); err != nil {
 			err = nil


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix issue with missing stdin configuration for k9s and kubectl commands.